### PR TITLE
Extract out path resolution from checksum cli command.

### DIFF
--- a/slicedimage/cli/checksum.py
+++ b/slicedimage/cli/checksum.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
-import sys
-
 from slicedimage import Reader, Writer
+from slicedimage.io import resolve_path_or_url
 from ._base import CliCommand
 
 
@@ -19,16 +17,8 @@ class ChecksumCommand(CliCommand):
 
     @classmethod
     def run_command(cls, args):
-        try:
-            slicedimage = Reader.parse_doc(args.in_url, None)
-        except ValueError:
-            if os.path.isfile(args.in_url):
-                newurl = "file://{}".format(args.in_url)
-                sys.stderr.write(
-                    "WARNING: {} is not a url but is a file.  Attempting {}...\n".format(args.in_url, newurl))
-                slicedimage = Reader.parse_doc(newurl, None)
-            else:
-                raise
+        _, name, baseurl = resolve_path_or_url(args.in_url)
+        slicedimage = Reader.parse_doc(name, baseurl)
 
         Writer.write_to_path(
             slicedimage,

--- a/slicedimage/io.py
+++ b/slicedimage/io.py
@@ -34,10 +34,29 @@ def infer_backend(baseurl, allow_caching=True):
     return backend
 
 
+def resolve_path_or_url(path_or_url, allow_caching=True):
+    """
+    Given either a path (absolute or relative), or a URL, attempt to resolve it.  Returns a tuple consisting of:
+    a :py:class:`slicedimage.backends._base.Backend`, the basename of the object, and the baseurl of the object.
+    """
+    try:
+        return resolve_url(path_or_url, allow_caching=allow_caching)
+    except ValueError:
+        if os.path.isfile(path_or_url):
+            return resolve_url(
+                os.path.basename(path_or_url),
+                baseurl="file://{}".format(os.path.dirname(os.path.abspath(path_or_url))),
+                allow_caching=allow_caching,
+            )
+        raise
+
+
 def resolve_url(name_or_url, baseurl=None, allow_caching=True):
     """
     Given a string that can either be a name or a fully qualified url, return a tuple consisting of:
     a :py:class:`slicedimage.backends._base.Backend`, the basename of the object, and the baseurl of the object.
+
+    If the string is a name and not a fully qualified url, then baseurl must be set.
     """
     try:
         # assume it's a fully qualified url.


### PR DESCRIPTION
It's useful to be able to resolve a URL or an absolute/relative path.  Use case: `Stack().read("http://xyz")` or `Stack().read("ISS/fov_001/experiment.json")`

Improve the documentation for `resolve_url`.