### PR TITLE
Fix multilevel TOC write

### DIFF
--- a/slicedimage/io.py
+++ b/slicedimage/io.py
@@ -102,12 +102,13 @@ class Writer(object):
     @staticmethod
     def default_toc_path_generator(toc_path):
         toc_basename = os.path.splitext(os.path.basename(toc_path))[0]
-        return tempfile.NamedTemporaryFile(
+        toc_path = tempfile.NamedTemporaryFile(
             suffix=".json",
             prefix="{}-".format(toc_basename),
             dir=os.path.dirname(toc_path),
             delete=False,
         )
+        return toc_path.name
 
     @staticmethod
     def default_tile_opener(toc_path, tile, ext):
@@ -194,14 +195,16 @@ class v0_0_0(object):
                 CommonPartitionKeys.EXTRAS: imagestack.extras,
             }
             if isinstance(imagestack, TocPartition):
+                json_doc[TocPartitionKeys.TOCS] = []
                 for toc in imagestack._tocs:
-                    tocpath = toc_path_generator(path, toc)
+                    tocpath = toc_path_generator(path)
                     Writer.write_to_path(
                         toc, tocpath,
                         toc_path_generator=toc_path_generator,
                         tile_opener=tile_opener,
-                        tile_Writer=tile_writer
+                        tile_writer=tile_writer
                     )
+                    json_doc[TocPartitionKeys.TOCS].append(os.path.basename(tocpath))
                 return json_doc
             elif isinstance(imagestack, ImagePartition):
                 json_doc[ImagePartitionKeys.DIMENSIONS] = tuple(imagestack.dimensions)

--- a/tests/io/v0_0_0/test_write.py
+++ b/tests/io/v0_0_0/test_write.py
@@ -66,3 +66,53 @@ class TestWrite(unittest.TestCase):
 
                     self.assertEqual(tiles[0].numpy_array.all(), expected.all())
                     self.assertIsNotNone(tiles[0].sha256)
+
+    def test_write_tocpartition(self):
+        image = slicedimage.ImagePartition(
+            ["x", "y", "ch", "hyb"],
+            {'ch': 2, 'hyb': 2},
+            (100, 100),
+        )
+
+        for hyb in range(2):
+            for ch in range(2):
+                tile = slicedimage.Tile(
+                    {
+                        'x': (0.0, 0.01),
+                        'y': (0.0, 0.01),
+                    },
+                    {
+                        'hyb': hyb,
+                        'ch': ch,
+                    },
+                )
+                tile.numpy_array = numpy.zeros((100, 100))
+                tile.numpy_array[hyb, ch] = 1
+                image.add_tile(tile)
+        toc = slicedimage.TocPartition()
+        toc.add_toc(image)
+
+        with TemporaryDirectory() as tempdir, tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as toc_file:
+            toc_doc = slicedimage.v0_0_0.Writer().generate_toc(toc, toc_file.name)
+            writer = codecs.getwriter("utf-8")
+            json.dump(toc_doc, writer(toc_file))
+            toc_file.flush()
+
+            basename = os.path.basename(toc_file.name)
+            baseurl = "file://{}".format(os.path.dirname(toc_file.name))
+
+            loaded = slicedimage.Reader.parse_doc(basename, baseurl)
+
+            for hyb in range(2):
+                for ch in range(2):
+                    tiles = [_tile
+                             for _tile in loaded.tiles(lambda tile:
+                                                       tile.indices['hyb'] == hyb and tile.indices['ch'] == ch)]
+
+                    self.assertEqual(len(tiles), 1)
+
+                    expected = numpy.zeros((100, 100))
+                    expected[hyb, ch] = 1
+
+                    self.assertEqual(tiles[0].numpy_array.all(), expected.all())
+                    self.assertIsNotNone(tiles[0].sha256)


### PR DESCRIPTION
1. toc_path_generator should take one argument (path of the previous level TOC).
2. Add the sub-tocs to the output.
3. Add test to cover these code paths.