### PR TITLE
Multilevel TOCs should have names.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,10 @@ The location for each tile is given in coordinates and indices.  Coordinates is 
 Format
 ------
 
-Each image set should have a manifest, which is a hierarchical tree of JSON table-of-contents documents.  The leaf TOC documents contain list of tiles (`Image partition TOC`_) and the non-leaf TOC documents (`TOC partition`_) contain lists of other TOC documents.
+Each image should have a manifest, which is a hierarchical tree of JSON table-of-contents documents.  The leaf documents (`Image partition`_) contain a list of tiles.  The non-leaf documents (`TOC partition`_) contain a map from an arbitrary unique name (within the space of the entire image) to relative paths or URLs containing either other `TOC partitions`__ or `image partitions`__.
+
+__ `TOC partition`_
+__ `Image partition`_
 
 .. _`TOC partition`:
 
@@ -35,17 +38,21 @@ TOC partitions should have the following fields:
 Field Name           Type    Required  Description
 -------------------  ------  --------  ---------------------------------------------------------------------------------
 version              string  Yes       Semantic versioning of the file format.
-tocs                 list    Yes       List of relative paths or URLs to other TOC files.
+tocs                 dict    Yes       Map of names to relative paths or URLs of `image partitions`__ or
+                                       `TOC partition`__.
 extras               dict    No        Additional application-specific payload.  The vocabulary and the schema are
                                        uncontrolled.
 ===================  ======  ========  =================================================================================
 
-.. _`Image partition TOC`:
+__ `Image partition`_
+__ `TOC partition`_
 
-Image partition TOC
-~~~~~~~~~~~~~~~~~~~
+.. _`Image partition`:
 
-Image partition TOCs should have the following fields:
+Image partition
+~~~~~~~~~~~~~~~
+
+Image partitions should have the following fields:
 
 ===================  ======  ========  =================================================================================
 Field Name           Type    Required  Description

--- a/tests/io/v0_0_0/test_reader.py
+++ b/tests/io/v0_0_0/test_reader.py
@@ -24,17 +24,15 @@ class TestReader(unittest.TestCase):
     def test_read_tocpartition(self):
         result = slicedimage.Reader.parse_doc("tocpartition_l1.json", baseurl)
         self.assertIsInstance(result, slicedimage.TocPartition)
-        tocs = [toc for toc in result.all_tocs()]
-        self.assertEqual(len(tocs), 1)
-        self.assertEqual(tocs[0].shape, {'hyb': 4, 'ch': 4})
+        toc = result.find_image_partition("fov_001")
+        self.assertEqual(toc.shape, {'hyb': 4, 'ch': 4})
         self._verify_tiles(result.tiles())
 
     def test_read_multilevel_tpartition(self):
         result = slicedimage.Reader.parse_doc("tocpartition_l2.json", baseurl)
         self.assertIsInstance(result, slicedimage.TocPartition)
-        tocs = [toc for toc in result.all_tocs()]
-        self.assertEqual(len(tocs), 1)
-        self.assertEqual(tocs[0].shape, {'hyb': 4, 'ch': 4})
+        toc = result.find_image_partition("fov_001")
+        self.assertEqual(toc.shape, {'hyb': 4, 'ch': 4})
         self._verify_tiles(result.tiles())
 
     def _verify_tiles(self, tile_generator):

--- a/tests/io/v0_0_0/test_write.py
+++ b/tests/io/v0_0_0/test_write.py
@@ -90,7 +90,7 @@ class TestWrite(unittest.TestCase):
                 tile.numpy_array[hyb, ch] = 1
                 image.add_tile(tile)
         toc = slicedimage.TocPartition()
-        toc.add_toc(image)
+        toc.add_partition("fov002", image)
 
         with TemporaryDirectory() as tempdir, tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as toc_file:
             toc_doc = slicedimage.v0_0_0.Writer().generate_toc(toc, toc_file.name)

--- a/tests/io/v0_0_0/tocpartition_l1.json
+++ b/tests/io/v0_0_0/tocpartition_l1.json
@@ -1,6 +1,6 @@
 {
     "version": "0.0.0",
-    "tocs": [
-        "imagepartition.json"
-    ]
+    "tocs": {
+        "fov_001": "imagepartition.json"
+    }
 }

--- a/tests/io/v0_0_0/tocpartition_l2.json
+++ b/tests/io/v0_0_0/tocpartition_l2.json
@@ -1,6 +1,6 @@
 {
     "version": "0.0.0",
-    "tocs": [
-        "tocpartition_l1.json"
-    ]
+    "tocs": {
+        "toc001": "tocpartition_l1.json"
+    }
 }


### PR DESCRIPTION
Each TOC in a multilevel TOC should have a logical name.  This allows us to find a specific TOC (a.k.a. FOV in starfish parlance) by name.

Depends on #7 