### PR TITLE
fix tile_shape handling if it's not provided.

### DIFF
--- a/slicedimage/_tileset.py
+++ b/slicedimage/_tileset.py
@@ -8,7 +8,7 @@ class TileSet(object):
     def __init__(self, dimensions, shape, default_tile_shape=None, default_tile_format=None, extras=None):
         self.dimensions = format_tileset_dimensions(dimensions)
         self.shape = format_tileset_shape(shape)
-        self.default_tile_shape = tuple() if default_tile_shape is None else tuple(default_tile_shape)
+        self.default_tile_shape = None if default_tile_shape is None else tuple(default_tile_shape)
         self.default_tile_format = default_tile_format
         self.extras = {} if extras is None else extras
         self._tiles = []


### PR DESCRIPTION
https://github.com/spacetx/slicedimage/pull/13 provides the wrong default value.  It should be None if it's not present, or a tuple if it's present.