### PR TITLE
Add a seekable argument to the read_file_handle_callable methods.

### DIFF
--- a/slicedimage/_formats.py
+++ b/slicedimage/_formats.py
@@ -17,12 +17,19 @@ def numpy_reader():
 
 class ImageFormat(enum.Enum):
     TIFF = (skimage_reader, "tiff", {"tif"})
-    NUMPY = (numpy_reader, "npy")
+    NUMPY = (numpy_reader, "npy", {}, True)
 
-    def __init__(self, reader_func, file_ext, alternate_extensions=None):
+    def __init__(
+            self,
+            reader_func,
+            file_ext,
+            alternate_extensions,
+            requires_seekable_file_handles=False,
+    ):
         self._reader_func = reader_func
         self._file_ext = file_ext
         self._alternate_extensions = set() if alternate_extensions is None else alternate_extensions
+        self._requires_seekable_file_handles = requires_seekable_file_handles
 
     @staticmethod
     def find_by_extension(extension):
@@ -42,3 +49,11 @@ class ImageFormat(enum.Enum):
     @property
     def file_ext(self):
         return self._file_ext
+
+    @property
+    def requires_seekable_file_handles(self):
+        """
+        The reader method of some file formats require the ability to seek inside the file.  If this
+        is True, we will buffer the data so it is possible to seek.
+        """
+        return self._requires_seekable_file_handles

--- a/slicedimage/backends/_base.py
+++ b/slicedimage/backends/_base.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 
 class Backend(object):
-    def read_file_handle_callable(self, name, checksum_sha1=None):
+    def read_file_handle_callable(self, name, checksum_sha1=None, seekable=False):
         raise NotImplementedError()
 
     def read_file_handle(self, name, checksum_sha1=None):

--- a/slicedimage/backends/_caching.py
+++ b/slicedimage/backends/_caching.py
@@ -10,7 +10,7 @@ class CachingBackend(Backend):
         self._cacheroot = cacheroot
         self._authoritative_backend = authoritative_backend
 
-    def read_file_handle_callable(self, name, checksum_sha1=None):
+    def read_file_handle_callable(self, name, checksum_sha1=None, seekable=False):
         # TODO: (ttung) This is a very very primitive cache.  Should make this more robust with
         # evictions and all that good stuff.
         cachedir = os.path.join(self._cacheroot, checksum_sha1[0:2], checksum_sha1[2:4])

--- a/slicedimage/backends/_disk.py
+++ b/slicedimage/backends/_disk.py
@@ -9,7 +9,7 @@ class DiskBackend(Backend):
     def __init__(self, basedir):
         self._basedir = basedir
 
-    def read_file_handle_callable(self, name, checksum_sha1=None):
+    def read_file_handle_callable(self, name, checksum_sha1=None, seekable=False):
         return lambda: open(os.path.join(self._basedir, name), "rb")
 
     def write_file_handle(self, name=None):

--- a/slicedimage/backends/_http.py
+++ b/slicedimage/backends/_http.py
@@ -1,18 +1,31 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import requests
+from six import BytesIO
 
 from slicedimage.urlpath import pathjoin
 from ._base import Backend
+
+
+class _BytesIOContextManager(BytesIO):
+    """Extension to BytesIO, but supports acting like a context manager."""
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
 
 
 class HttpBackend(Backend):
     def __init__(self, baseurl):
         self._baseurl = baseurl
 
-    def read_file_handle_callable(self, name, checksum_sha1=None):
+    def read_file_handle_callable(self, name, checksum_sha1=None, seekable=False):
         def returned_callable():
             parsed = pathjoin(self._baseurl, name)
+            if seekable:
+                req = requests.get(parsed)
+                return _BytesIOContextManager(req.content)
             req = requests.get(parsed, stream=True)
             return req.raw
         return returned_callable

--- a/slicedimage/io.py
+++ b/slicedimage/io.py
@@ -198,7 +198,10 @@ class v0_0_0(object):
                         extras=tile_doc.get(TileKeys.EXTRAS, None),
                     )
                     tile.set_source_fh_contextmanager(
-                        backend.read_file_handle_callable(name), tile_format)
+                        backend.read_file_handle_callable(
+                            name,
+                            seekable=tile_format.requires_seekable_file_handles),
+                        tile_format)
                     tile._file_or_url = relative_path_or_url
                     result.add_tile(tile)
             else:


### PR DESCRIPTION
If true, this forces the backend to return a seekable handle.  The short version is that this means we do not use streaming, and we have to buffer the contents.  This increases our memory consumption by ~2x, but it should be survivable.

Add a test for loading numpy arrays over http.  Fails without the changes in slicedimage/{backends/*,io.py}, but passes with the changes.  Yay!

Depends on #20 