### PR TITLE
Fix resolution of relative paths with a path component.

### DIFF
--- a/slicedimage/io.py
+++ b/slicedimage/io.py
@@ -9,7 +9,7 @@ import tempfile
 from packaging import version
 from six.moves import urllib
 
-from slicedimage.urlpath import pathsplit
+from slicedimage.urlpath import pathjoin, pathsplit
 from .backends import DiskBackend, HttpBackend
 from ._collection import Collection
 from ._formats import ImageFormat
@@ -58,26 +58,35 @@ def resolve_path_or_url(path_or_url, allow_caching=True):
         raise
 
 
+def _resolve_absolute_url(absolute_url, allow_caching):
+    """
+    Given a string that is an absolute URL, return a tuple consisting of: a
+    :py:class:`slicedimage.backends._base.Backend`, the basename of the object, and the baseurl of
+    the object.
+    """
+    splitted = pathsplit(absolute_url)
+    backend = infer_backend(splitted[0], allow_caching)
+    return backend, splitted[1], splitted[0]
+
+
 def resolve_url(name_or_url, baseurl=None, allow_caching=True):
     """
     Given a string that can either be a name or a fully qualified url, return a tuple consisting of:
     a :py:class:`slicedimage.backends._base.Backend`, the basename of the object, and the baseurl of
     the object.
 
-    If the string is a name and not a fully qualified url, then baseurl must be set.
+    If the string is a name and not a fully qualified url, then baseurl must be set.  If the string
+    is a fully qualified url, then baseurl is ignored.
     """
     try:
         # assume it's a fully qualified url.
-        splitted = pathsplit(name_or_url)
-        backend = infer_backend(splitted[0], allow_caching)
-        return backend, splitted[1], splitted[0]
+        return _resolve_absolute_url(name_or_url, allow_caching)
     except ValueError:
         if baseurl is None:
             # oh, we have no baseurl.  punt.
             raise
-        # it's not a fully qualified url.
-        backend = infer_backend(baseurl, allow_caching)
-        return backend, name_or_url, baseurl
+        absolute_url = pathjoin(baseurl, name_or_url)
+        return _resolve_absolute_url(absolute_url, allow_caching)
 
 
 class Reader(object):

--- a/tests/io/test_resolve_url.py
+++ b/tests/io/test_resolve_url.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import tempfile
+import unittest
+import uuid
+
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+
+from slicedimage.io import resolve_path_or_url, resolve_url
+
+
+class TestResolvePathOrUrl(unittest.TestCase):
+    def test_valid_local_path(self):
+        with tempfile.NamedTemporaryFile() as tfn:
+            abspath = os.path.realpath(tfn.name)
+            _, name, baseurl = resolve_path_or_url(abspath)
+            self.assertEqual(name, os.path.basename(abspath))
+            self.assertEqual("file://{}".format(os.path.dirname(abspath)), baseurl)
+
+            cwd = os.getcwd()
+            try:
+                os.chdir(os.path.dirname(abspath))
+                _, name, baseurl = resolve_path_or_url(os.path.basename(abspath))
+                self.assertEqual(name, os.path.basename(abspath))
+                self.assertEqual("file://{}".format(os.path.dirname(abspath)), baseurl)
+            finally:
+                os.chdir(cwd)
+
+    def test_invalid_local_path(self):
+        with self.assertRaises(ValueError):
+            resolve_path_or_url(str(uuid.uuid4()))
+
+    def test_url(self):
+        _, name, baseurl = resolve_path_or_url("https://github.com/abc/def")
+        self.assertEqual(name, "def")
+        self.assertEqual(baseurl, "https://github.com/abc")
+
+
+class TestResolveUrl(unittest.TestCase):
+    def test_fully_qualified_url(self):
+        _, name, baseurl = resolve_url("https://github.com/abc/def")
+        self.assertEqual(name, "def")
+        self.assertEqual(baseurl, "https://github.com/abc")
+
+        # even with a baseurl, this should work.
+        _, name, baseurl = resolve_url("https://github.com/abc/def", "https://github.io")
+        self.assertEqual(name, "def")
+        self.assertEqual(baseurl, "https://github.com/abc")
+
+    def test_relative_url(self):
+        _, name, baseurl = resolve_url("def", "https://github.com/abc")
+        self.assertEqual(name, "def")
+        self.assertEqual(baseurl, "https://github.com/abc")
+
+        # even with a path separator in the relative path, it should work.
+        _, name, baseurl = resolve_url("abc/def", "https://github.com/")
+        self.assertEqual(name, "def")
+        self.assertEqual(baseurl, "https://github.com/abc")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
url = "abc/def", baseurl = "https://github.com/" should resolve to name=def, baseurl = "https://github.com/abc", but it wasn't previously.

Added test cases for all the resolve_* methods.

Fixes #25