### PR TITLE
Remove import hack.

### DIFF
--- a/tests/io/test_resolve_url.py
+++ b/tests/io/test_resolve_url.py
@@ -1,13 +1,7 @@
 import os
-import sys
 import tempfile
 import unittest
 import uuid
-
-
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))  # noqa
-sys.path.insert(0, pkg_root)  # noqa
-
 
 from slicedimage.io import resolve_path_or_url, resolve_url
 

--- a/tests/io/v0_0_0/test_caching_backend.py
+++ b/tests/io/v0_0_0/test_caching_backend.py
@@ -10,12 +10,12 @@ import requests
 import skimage.io
 
 import slicedimage
-
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))  # noqa
-sys.path.insert(0, pkg_root)  # noqa
-
-from tests.utils import build_skeleton_manifest, ContextualChildProcess, \
-    TemporaryDirectory, unused_tcp_port
+from tests.utils import (
+    build_skeleton_manifest,
+    ContextualChildProcess,
+    TemporaryDirectory,
+    unused_tcp_port,
+)
 
 
 class TestCachingBackend(unittest.TestCase):

--- a/tests/io/v0_0_0/test_http_backend.py
+++ b/tests/io/v0_0_0/test_http_backend.py
@@ -8,13 +8,13 @@ import numpy as np
 import requests
 import skimage.io
 
-
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))  # noqa
-sys.path.insert(0, pkg_root)  # noqa
-
 import slicedimage
-from tests.utils import build_skeleton_manifest, ContextualChildProcess, \
-    TemporaryDirectory, unused_tcp_port
+from tests.utils import (
+    build_skeleton_manifest,
+    ContextualChildProcess,
+    TemporaryDirectory,
+    unused_tcp_port,
+)
 
 
 class TestHttpBackend(unittest.TestCase):

--- a/tests/io/v0_0_0/test_reader.py
+++ b/tests/io/v0_0_0/test_reader.py
@@ -1,12 +1,6 @@
 import collections
 import os
-import sys
 import unittest
-
-
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))  # noqa
-sys.path.insert(0, pkg_root)  # noqa
-
 
 import slicedimage
 

--- a/tests/io/v0_0_0/test_write.py
+++ b/tests/io/v0_0_0/test_write.py
@@ -2,14 +2,8 @@ import codecs
 import json
 import numpy
 import os
-import sys
 import tempfile
 import unittest
-
-
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))  # noqa
-sys.path.insert(0, pkg_root)  # noqa
-
 
 import slicedimage
 from tests.utils import TemporaryDirectory


### PR DESCRIPTION
Import hack is only necessary if one does not run `pip install -e .`, and that's a logical thing to do for libraries.

Also cleaned up some import statements.

Fixes #31