### PR TITLE
Convert read_file_handle{,_callable} to read_contextmanager

### DIFF
--- a/slicedimage/_tile.py
+++ b/slicedimage/_tile.py
@@ -23,7 +23,7 @@ class Tile(object):
         if self._source_fh_contextmanager is not None:
             assert self._numpy_array is None, ("Inconsistent state.  Tile should only have one "
                                                "data source.")
-            with self._source_fh_contextmanager() as src_fh:
+            with self._source_fh_contextmanager as src_fh:
                 self._numpy_array = self.tile_format.reader_func(src_fh)
             self._source_fh_contextmanager = None
             self.tile_format = ImageFormat.NUMPY
@@ -72,7 +72,7 @@ class Tile(object):
         """
         if self._source_fh_contextmanager is not None:
             assert self._numpy_array is None
-            with self._source_fh_contextmanager() as src_fh:
+            with self._source_fh_contextmanager as src_fh:
                 data = src_fh.read()
                 self._numpy_array = self.tile_format.reader_func(BytesIO(data))
                 dst_fh.write(data)

--- a/slicedimage/backends/_base.py
+++ b/slicedimage/backends/_base.py
@@ -2,11 +2,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 
 class Backend(object):
-    def read_file_handle_callable(self, name, checksum_sha256=None, seekable=False):
+    def read_contextmanager(self, name, checksum_sha256=None, seekable=False):
         raise NotImplementedError()
-
-    def read_file_handle(self, name, checksum_sha1=None):
-        return self.read_file_handle_callable(name, checksum_sha1)()
 
     def write_file_handle(self, name):
         raise NotImplementedError()

--- a/slicedimage/backends/_caching.py
+++ b/slicedimage/backends/_caching.py
@@ -13,42 +13,60 @@ CACHE_VERSION = "v0"
 
 
 class CachingBackend(Backend):
-
     def __init__(self, cacheroot, authoritative_backend):
         self._cacheroot = cacheroot
         self._authoritative_backend = authoritative_backend
-        self.cache = Cache(cacheroot, size_limit=int(SIZE_LIMIT))
+        self._cache = Cache(cacheroot, size_limit=int(SIZE_LIMIT))
 
-    def read_file_handle_callable(self, name, checksum_sha256=None, seekable=False):
-        def returned_callable():
-            if checksum_sha256:
-                cache_key = "{}-{}".format(CACHE_VERSION, checksum_sha256)
-                try:
-                    file_data = self.cache.read(cache_key)
-                except KeyError:
-                    # not in cache :(
-                    sfh = self._authoritative_backend.read_file_handle(name)
-                    file_data = sfh.read()
-                    # TODO: consider removing this if we land a more generalized solution that
-                    # protects against corruption regardless of backend.
-                    sha256 = hashlib.sha256(file_data).hexdigest()
-                    if sha256 != checksum_sha256:
-                        warnings.warn(
-                            "Checksum of tile data does not match the manifest checksum!  Not "
-                            "writing to cache")
-                    else:
-                        self.cache.set(cache_key, file_data)
-                    return io.BytesIO(file_data)
-                else:
-                    # If the data is small enough, the DiskCache library returns the cache data
-                    # as bytes instead of a buffered reader.
-                    # In that case, we want to wrap it in a file-like object.
-                    if isinstance(file_data, io.IOBase):
-                        return file_data
-                    return io.BytesIO(file_data)
-            else:
-                return self._authoritative_backend.read_file_handle(name)
-        return returned_callable
+    def read_contextmanager(self, name, checksum_sha256=None, seekable=False):
+        if checksum_sha256 is not None:
+            return _CachingBackendContextManager(
+                self._authoritative_backend, self._cache, name, checksum_sha256)
+        else:
+            return self._authoritative_backend.read_contextmanager(
+                name, checksum_sha256, seekable=seekable)
 
     def write_file_handle(self, name):
         return self._authoritative_backend.write_file_handle(name)
+
+
+class _CachingBackendContextManager(object):
+    def __init__(self, authoritative_backend, cache, name, checksum_sha256):
+        self.authoritative_backend = authoritative_backend
+        self.cache = cache
+        self.name = name
+        self.checksum_sha256 = checksum_sha256
+        self.handle = None
+
+    def __enter__(self):
+        cache_key = "{}-{}".format(CACHE_VERSION, self.checksum_sha256)
+        try:
+            file_data = self.cache.read(cache_key)
+        except KeyError:
+            # not in cache :(
+            with self.authoritative_backend.read_contextmanager(self.name) as sfh:
+                file_data = sfh.read()
+            # TODO: consider removing this if we land a more generalized solution that
+            # protects against corruption regardless of backend.
+            sha256 = hashlib.sha256(file_data).hexdigest()
+            if sha256 != self.checksum_sha256:
+                warnings.warn(
+                    "Checksum of tile data does not match the manifest checksum!  Not "
+                    "writing to cache")
+            else:
+                self.cache.set(cache_key, file_data)
+            self.handle = io.BytesIO(file_data)
+        else:
+            # If the data is small enough, the DiskCache library returns the cache data
+            # as bytes instead of a buffered reader.
+            # In that case, we want to wrap it in a file-like object.
+            if isinstance(file_data, io.IOBase):
+                self.handle = file_data
+            else:
+                self.handle = io.BytesIO(file_data)
+
+        return self.handle.__enter__()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.handle is not None:
+            return self.handle.__exit__(exc_type, exc_val, exc_tb)

--- a/slicedimage/backends/_disk.py
+++ b/slicedimage/backends/_disk.py
@@ -9,8 +9,23 @@ class DiskBackend(Backend):
     def __init__(self, basedir):
         self._basedir = basedir
 
-    def read_file_handle_callable(self, name, checksum_sha256=None, seekable=False):
-        return lambda: open(os.path.join(self._basedir, name), "rb")
+    def read_contextmanager(self, name, checksum_sha256=None, seekable=False):
+        return _FileLikeContextManager(os.path.join(self._basedir, name), checksum_sha256)
 
     def write_file_handle(self, name=None):
         return open(os.path.join(self._basedir, name), "wb")
+
+
+class _FileLikeContextManager(object):
+    def __init__(self, path, checksum_sha256):
+        self.path = path
+        self.checksum_sha256 = checksum_sha256
+        self.handle = None
+
+    def __enter__(self):
+        self.handle = open(self.path, "rb")
+        return self.handle
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.handle is not None:
+            return self.handle.__exit__(exc_type, exc_val, exc_tb)

--- a/slicedimage/backends/_http.py
+++ b/slicedimage/backends/_http.py
@@ -1,31 +1,37 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import requests
-from six import BytesIO
+from io import BytesIO
 
 from slicedimage.urlpath import pathjoin
 from ._base import Backend
-
-
-class _BytesIOContextManager(BytesIO):
-    """Extension to BytesIO, but supports acting like a context manager."""
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
 
 
 class HttpBackend(Backend):
     def __init__(self, baseurl):
         self._baseurl = baseurl
 
-    def read_file_handle_callable(self, name, checksum_sha256=None, seekable=False):
-        def returned_callable():
-            parsed = pathjoin(self._baseurl, name)
-            if seekable:
-                req = requests.get(parsed)
-                return _BytesIOContextManager(req.content)
-            req = requests.get(parsed, stream=True)
-            return req.raw
-        return returned_callable
+    def read_contextmanager(self, name, checksum_sha256=None, seekable=False):
+        parsed = pathjoin(self._baseurl, name)
+        return _UrlContextManager(parsed, checksum_sha256, seekable)
+
+
+class _UrlContextManager(object):
+    def __init__(self, url, checksum_sha256, seekable):
+        self.url = url
+        self.checksum_sha256 = checksum_sha256
+        self.seekable = seekable
+        self.handle = None
+
+    def __enter__(self):
+        if self.seekable:
+            req = requests.get(self.url)
+            self.handle = BytesIO(req.content)
+        else:
+            req = requests.get(self.url, stream=True)
+            self.handle = req.raw
+        return self.handle.__enter__()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.handle is not None:
+            return self.handle.__exit__(exc_type, exc_val, exc_tb)

--- a/slicedimage/cli/checksum.py
+++ b/slicedimage/cli/checksum.py
@@ -56,6 +56,6 @@ def fake_file_opener(partition_path, tile, ext):
 
 def identity_writer(tile, fh):
     assert tile._source_fh_contextmanager is not None
-    with tile._source_fh_contextmanager() as sfh:
+    with tile._source_fh_contextmanager as sfh:
         fh.write(sfh.read())
     return tile.tile_format

--- a/slicedimage/io.py
+++ b/slicedimage/io.py
@@ -90,9 +90,9 @@ class Reader(object):
     @staticmethod
     def parse_doc(name_or_url, baseurl):
         backend, name, baseurl = resolve_url(name_or_url, baseurl)
-        fh = backend.read_file_handle(name)
-        reader = codecs.getreader("utf-8")
-        json_doc = json.load(reader(fh))
+        with backend.read_contextmanager(name) as fh:
+            reader = codecs.getreader("utf-8")
+            json_doc = json.load(reader(fh))
         doc_version = version.parse(json_doc[CommonPartitionKeys.VERSION])
 
         try:
@@ -195,7 +195,7 @@ class v0_0_0(object):
                         extras=tile_doc.get(TileKeys.EXTRAS, None),
                     )
                     tile.set_source_fh_contextmanager(
-                        backend.read_file_handle_callable(
+                        backend.read_contextmanager(
                             name,
                             checksum_sha256=checksum,
                             seekable=tile_format.requires_seekable_file_handles),


### PR DESCRIPTION
Context managers checks the feature list we need for this interface: an object that promises a file-like read handle, but doesn't do the work until it's invoked.  Previously, we did this by returning a method that, when called, would return the file-like handle.  The downside is that we can't execute any cleanup logic.  With context managers, we can require that a block of code is executed once the file-like read handle is no longer necessary.

Currently, this is just used to close the file handle (by invoking the wrapped context managers's __exit__method), but the next step is to use this cleanup block to verify that the data read matched the checksums.