### PR TITLE
Context manager that acts like a file and verifies checksums

### DIFF
--- a/slicedimage/backends/__init__.py
+++ b/slicedimage/backends/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from ._base import ChecksumValidationError
 from ._caching import CachingBackend
 from ._disk import DiskBackend
 from ._http import HttpBackend
@@ -7,6 +8,7 @@ from ._http import HttpBackend
 
 __all__ = [
     CachingBackend,
+    ChecksumValidationError,
     DiskBackend,
     HttpBackend,
 ]

--- a/slicedimage/backends/_base.py
+++ b/slicedimage/backends/_base.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import hashlib
+import io
+
 
 class Backend(object):
     def read_contextmanager(self, name, checksum_sha256=None, seekable=False):
@@ -16,5 +19,58 @@ class Backend(object):
             dest_handle.write(data)
 
 
-class FileNotFoundError(Exception):
+class ChecksumValidationError(ValueError):
+    """Raised when the downloaded file does not match the expected checksum."""
     pass
+
+
+class CalculateFileObjectChecksum(object):
+    """
+    Context manager that wraps another context manager that returns a readable file handle.
+    `CalculateFileObjectChecksum` will wrap the returned readable file handle such that a sha256
+    checksum is calculated against the data read.  If the file is not read to completion by the time
+    the context manager exits, it is read to completion so that the entire file's contents is
+    checksummed.
+
+    If the checksum does not match the expected sha256, raise ChecksumValidationError.
+    """
+    def __init__(self, wrapped_file_contextmanager, expected_sha256_checksum):
+        self._wrapped_file_contextmanager = wrapped_file_contextmanager
+        self._io = None
+        self._checksummer = hashlib.sha256()
+        self._expected_sha256_checksum = expected_sha256_checksum
+
+    def __enter__(self):
+        if self._expected_sha256_checksum is None:
+            self._io = self._wrapped_file_contextmanager.__enter__()
+        else:
+            self._io = _ChecksummingFile(
+                self._wrapped_file_contextmanager.__enter__(), self._checksummer)
+        return self._io
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # finish reading the data.
+        self._io.read()
+        calculated_checksum = self._checksummer.hexdigest()
+        if (self._expected_sha256_checksum is not None and
+                calculated_checksum != self._expected_sha256_checksum):
+            raise ChecksumValidationError(
+                "calculated checksum ({}) does not match expected checksum ({})".format(
+                    calculated_checksum, self._expected_sha256_checksum))
+
+        return self._wrapped_file_contextmanager.__exit__(exc_type, exc_val, exc_tb)
+
+
+class _ChecksummingFile(io.IOBase):
+    """
+    Read-only file-like handle that delegates read calls to a wrapped file-like handle.  As the file
+    is read, a checksum is calculated on the data read.
+    """
+    def __init__(self, wrapped_io, checksummer):
+        self._wrapped_io = wrapped_io
+        self._checksummer = checksummer
+
+    def read(self, size=-1):
+        data = self._wrapped_io.read(size)
+        self._checksummer.update(data)
+        return data

--- a/tests/io/test_calculate_file_object_checksum.py
+++ b/tests/io/test_calculate_file_object_checksum.py
@@ -1,0 +1,50 @@
+import hashlib
+import unittest
+from io import IOBase, BytesIO
+
+from slicedimage.backends._base import CalculateFileObjectChecksum
+
+
+class TestCalculateFileObjectChecksum(unittest.TestCase):
+    def test_instanceof(self, test_inp=b"abcde"):
+        obj = BytesIO(test_inp)
+        with CalculateFileObjectChecksum(obj, None) as fh:
+            self.assertIsInstance(fh, IOBase)
+
+    def test_read(self, test_inp=b"abcde"):
+        obj = BytesIO(test_inp)
+        with CalculateFileObjectChecksum(obj, None) as fh:
+            self.assertEqual(fh.read(2), b"ab")
+            self.assertEqual(fh.read(1), b"c")
+            self.assertEqual(fh.read(), b"de")
+
+    def test_checksum_read(self, test_inp=b"abcde"):
+        obj = BytesIO(test_inp)
+        hasher = hashlib.sha256()
+        hasher.update(test_inp)
+        expected_sha256 = hasher.hexdigest()
+
+        with CalculateFileObjectChecksum(obj, expected_sha256) as fh:
+            self.assertEqual(fh.read(2), b"ab")
+            self.assertEqual(fh.read(1), b"c")
+            self.assertEqual(fh.read(), b"de")
+
+    def test_checksum_mismatch(self, test_inp=b"abcde"):
+        obj = BytesIO(test_inp)
+
+        with self.assertRaises(ValueError):
+            with CalculateFileObjectChecksum(obj, "not-the-right-checksum") as fh:
+                fh.read(5)
+
+    def test_checksum_incomplete_read(self, test_inp=b"abcde"):
+        obj = BytesIO(test_inp)
+        hasher = hashlib.sha256()
+        hasher.update(test_inp)
+        expected_sha256 = hasher.hexdigest()
+
+        with CalculateFileObjectChecksum(obj, expected_sha256) as fh:
+            fh.read(3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
ChecksummingContextManager yields a ChecksummingFile, which acts like a file, but delegates the read(..) method to an internal file-like object. As data is read, it's fed into the checksum calculation. When the context manager is exited, we finish reading the file, and then verify against the expected checksum.

Test plan: See test code.

Depends on #40 