### PR TITLE
Integrate checksumming

### DIFF
--- a/slicedimage/backends/_caching.py
+++ b/slicedimage/backends/_caching.py
@@ -1,12 +1,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import hashlib
 import io
-import warnings
 
 from diskcache import Cache
 
-from ._base import Backend
+from ._base import Backend, CalculateFileObjectChecksum
 
 SIZE_LIMIT = 5e9
 CACHE_VERSION = "v0"
@@ -46,24 +44,21 @@ class _CachingBackendContextManager(object):
             # not in cache :(
             with self.authoritative_backend.read_contextmanager(self.name) as sfh:
                 file_data = sfh.read()
-            # TODO: consider removing this if we land a more generalized solution that
-            # protects against corruption regardless of backend.
-            sha256 = hashlib.sha256(file_data).hexdigest()
-            if sha256 != self.checksum_sha256:
-                warnings.warn(
-                    "Checksum of tile data does not match the manifest checksum!  Not "
-                    "writing to cache")
-            else:
-                self.cache.set(cache_key, file_data)
+            self.cache.set(cache_key, file_data)
             self.handle = io.BytesIO(file_data)
+
+            # we are directly returning the data from the authoritative backend, which we assume
+            # is verifying the checksum, so we don't layer on another checksum calculation.
         else:
             # If the data is small enough, the DiskCache library returns the cache data
             # as bytes instead of a buffered reader.
             # In that case, we want to wrap it in a file-like object.
             if isinstance(file_data, io.IOBase):
-                self.handle = file_data
+                handle = file_data
             else:
-                self.handle = io.BytesIO(file_data)
+                handle = io.BytesIO(file_data)
+
+            self.handle = CalculateFileObjectChecksum(handle, self.checksum_sha256)
 
         return self.handle.__enter__()
 

--- a/slicedimage/backends/_disk.py
+++ b/slicedimage/backends/_disk.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import hashlib
 import os
 
-from ._base import Backend
+from ._base import Backend, ChecksumValidationError
 
 
 class DiskBackend(Backend):
@@ -17,13 +18,29 @@ class DiskBackend(Backend):
 
 
 class _FileLikeContextManager(object):
-    def __init__(self, path, checksum_sha256):
+    def __init__(self, path, checksum_sha256, read_chunk_size=1024 * 1024):
         self.path = path
         self.checksum_sha256 = checksum_sha256
         self.handle = None
+        self.read_chunk_size = read_chunk_size
 
     def __enter__(self):
         self.handle = open(self.path, "rb")
+        if self.checksum_sha256 is not None:
+            hasher = hashlib.sha256()
+            # calculate the checksum.  we don't use CalculateFileObjectChecksum because the
+            # file-like handle returned by DiskBackend supports seek operations.
+            while True:
+                data = self.handle.read(self.read_chunk_size)
+                if len(data) == 0:
+                    break
+                hasher.update(data)
+            calculated_checksum = hasher.hexdigest()
+            if calculated_checksum != self.checksum_sha256:
+                raise ChecksumValidationError(
+                    "calculated checksum ({}) does not match expected checksum ({})".format(
+                        calculated_checksum, self.checksum_sha256))
+            self.handle.seek(0)
         return self.handle
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/tests/io/v0_0_0/test_disk_backend.py
+++ b/tests/io/v0_0_0/test_disk_backend.py
@@ -1,0 +1,80 @@
+import hashlib
+import json
+import os
+import unittest
+
+import numpy as np
+import skimage.io
+
+import slicedimage
+from slicedimage.backends import ChecksumValidationError
+from tests.utils import (
+    build_skeleton_manifest,
+    TemporaryDirectory,
+)
+
+
+class TestDiskBackend(unittest.TestCase):
+    def test_checksum_good(self):
+        self._test_checksum(True)
+
+    def test_checksum_bad(self):
+        self._test_checksum(False)
+
+    def _test_checksum(self, good):
+        """
+        Generate a tileset consisting of a single TIFF tile.  If the parameter `good` is True, then
+        we provide the correct checksum and verify loading works correctly.  Otherwise, we provide
+        the incorrect checksum and verify that loading raises an exception.
+        """
+        # write the tiff file
+        with TemporaryDirectory() as tempdir:
+            data = np.random.randint(0, 65535, size=(100, 100), dtype=np.uint16)
+            file_path = os.path.join(tempdir, "tile.tiff")
+            skimage.io.imsave(file_path, data, plugin="tifffile")
+            if good:
+                with open(file_path, "rb") as fh:
+                    checksum = hashlib.sha256(fh.read()).hexdigest()
+            else:
+                checksum = hashlib.sha256().hexdigest()
+
+            manifest = build_skeleton_manifest()
+            manifest['tiles'].append(
+                {
+                    "coordinates": {
+                        "x": [
+                            0.0,
+                            0.0001,
+                        ],
+                        "y": [
+                            0.0,
+                            0.0001,
+                        ]
+                    },
+                    "indices": {
+                        "hyb": 0,
+                        "ch": 0,
+                    },
+                    "file": "tile.tiff",
+                    "format": "tiff",
+                    "sha256": checksum,
+                },
+            )
+            with open(os.path.join(tempdir, "tileset.json"), "w") as fh:
+                fh.write(json.dumps(manifest))
+
+            result = slicedimage.Reader.parse_doc(
+                "tileset.json",
+                "file://{}".format(tempdir),
+                allow_caching=False,
+            )
+
+            if good:
+                self.assertTrue(np.array_equal(list(result.tiles())[0].numpy_array, data))
+            else:
+                with self.assertRaises(ChecksumValidationError):
+                    result.tiles()[0]._load()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
1. If the data is available as a string, we calculate the checksum and verify.
2. If the data is available as a stream, we use ChecksummingContextManager to calculate the checksum as the stream is read.

Test plan: Add tests to verify that good and back checksums are detected.

Depends on #41, #44 