### PR TITLE
Remove the seekable parameter.

### DIFF
--- a/slicedimage/_formats.py
+++ b/slicedimage/_formats.py
@@ -17,19 +17,17 @@ def numpy_reader():
 
 class ImageFormat(enum.Enum):
     TIFF = (skimage_reader, "tiff", {"tif"})
-    NUMPY = (numpy_reader, "npy", {}, True)
+    NUMPY = (numpy_reader, "npy", {})
 
     def __init__(
             self,
             reader_func,
             file_ext,
             alternate_extensions,
-            requires_seekable_file_handles=False,
     ):
         self._reader_func = reader_func
         self._file_ext = file_ext
         self._alternate_extensions = set() if alternate_extensions is None else alternate_extensions
-        self._requires_seekable_file_handles = requires_seekable_file_handles
 
     @staticmethod
     def find_by_extension(extension):
@@ -49,11 +47,3 @@ class ImageFormat(enum.Enum):
     @property
     def file_ext(self):
         return self._file_ext
-
-    @property
-    def requires_seekable_file_handles(self):
-        """
-        The reader method of some file formats require the ability to seek inside the file.  If this
-        is True, we will buffer the data so it is possible to seek.
-        """
-        return self._requires_seekable_file_handles

--- a/slicedimage/backends/_base.py
+++ b/slicedimage/backends/_base.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 
 class Backend(object):
-    def read_contextmanager(self, name, checksum_sha256=None, seekable=False):
+    def read_contextmanager(self, name, checksum_sha256=None):
         raise NotImplementedError()
 
     def write_file_handle(self, name):

--- a/slicedimage/backends/_caching.py
+++ b/slicedimage/backends/_caching.py
@@ -18,13 +18,13 @@ class CachingBackend(Backend):
         self._authoritative_backend = authoritative_backend
         self._cache = Cache(cacheroot, size_limit=int(SIZE_LIMIT))
 
-    def read_contextmanager(self, name, checksum_sha256=None, seekable=False):
+    def read_contextmanager(self, name, checksum_sha256=None):
         if checksum_sha256 is not None:
             return _CachingBackendContextManager(
                 self._authoritative_backend, self._cache, name, checksum_sha256)
         else:
             return self._authoritative_backend.read_contextmanager(
-                name, checksum_sha256, seekable=seekable)
+                name, checksum_sha256)
 
     def write_file_handle(self, name):
         return self._authoritative_backend.write_file_handle(name)

--- a/slicedimage/backends/_disk.py
+++ b/slicedimage/backends/_disk.py
@@ -9,7 +9,7 @@ class DiskBackend(Backend):
     def __init__(self, basedir):
         self._basedir = basedir
 
-    def read_contextmanager(self, name, checksum_sha256=None, seekable=False):
+    def read_contextmanager(self, name, checksum_sha256=None):
         return _FileLikeContextManager(os.path.join(self._basedir, name), checksum_sha256)
 
     def write_file_handle(self, name=None):

--- a/slicedimage/backends/_http.py
+++ b/slicedimage/backends/_http.py
@@ -11,27 +11,21 @@ class HttpBackend(Backend):
     def __init__(self, baseurl):
         self._baseurl = baseurl
 
-    def read_contextmanager(self, name, checksum_sha256=None, seekable=False):
+    def read_contextmanager(self, name, checksum_sha256=None):
         parsed = pathjoin(self._baseurl, name)
-        return _UrlContextManager(parsed, checksum_sha256, seekable)
+        return _UrlContextManager(parsed, checksum_sha256)
 
 
 class _UrlContextManager(object):
-    def __init__(self, url, checksum_sha256, seekable):
+    def __init__(self, url, checksum_sha256):
         self.url = url
         self.checksum_sha256 = checksum_sha256
-        self.seekable = seekable
         self.handle = None
 
     def __enter__(self):
-        if self.seekable:
-            req = requests.get(self.url)
-            self.handle = BytesIO(req.content)
-        else:
-            req = requests.get(self.url, stream=True)
-            self.handle = req.raw
+        req = requests.get(self.url)
+        self.handle = BytesIO(req.content)
         return self.handle.__enter__()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.handle is not None:
-            return self.handle.__exit__(exc_type, exc_val, exc_tb)
+        return self.handle.__exit__(exc_type, exc_val, exc_tb)

--- a/slicedimage/io.py
+++ b/slicedimage/io.py
@@ -197,8 +197,7 @@ class v0_0_0(object):
                     tile.set_source_fh_contextmanager(
                         backend.read_contextmanager(
                             name,
-                            checksum_sha256=checksum,
-                            seekable=tile_format.requires_seekable_file_handles),
+                            checksum_sha256=checksum),
                         tile_format)
                     tile._file_or_url = relative_path_or_url
                     result.add_tile(tile)


### PR DESCRIPTION
We always want seekable=True.  Even though PIL claims to support streaming TIFF decoding, it actually reads into a [BytesIO object and decodes from that](https://pillow.readthedocs.io/en/3.0.x/releasenotes/2.8.0.html).  Therefore, there is no advantage to maintaining a streaming API.