### PR TITLE
Add checksum verification to disk and http backends

### DIFF
--- a/slicedimage/backends/__init__.py
+++ b/slicedimage/backends/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from ._base import ChecksumValidationError
 from ._caching import CachingBackend
 from ._disk import DiskBackend
 from ._http import HttpBackend
@@ -7,6 +8,7 @@ from ._http import HttpBackend
 
 __all__ = [
     CachingBackend,
+    ChecksumValidationError,
     DiskBackend,
     HttpBackend,
 ]

--- a/slicedimage/backends/_base.py
+++ b/slicedimage/backends/_base.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import hashlib
+
 
 class Backend(object):
     def read_contextmanager(self, name, checksum_sha256=None):
@@ -16,5 +18,37 @@ class Backend(object):
             dest_handle.write(data)
 
 
-class FileNotFoundError(Exception):
+class ChecksumValidationError(ValueError):
+    """Raised when the downloaded file does not match the expected checksum."""
     pass
+
+
+def verify_checksum(fh, expected_sha256_checksum, block_size=1024 * 1024):
+    """
+    Given a file-like handle, read from it in chunks to verify that the sha256 checksum matches
+    `expected_sha256_checksum`.  If the checksum does not match, raise `ChecksumValidationError`.
+
+    Before returning, the file handle is reset to the start of the file.
+    :param fh: The file-like handle.
+    :param expected_sha256_checksum: The expected sha256 checksum in hex.  If this parameter is
+                                     None, then the method immediately returns.
+    :param block_size: The block size of the IO.
+    """
+    if expected_sha256_checksum is None:
+        return
+
+    checksummer = hashlib.sha256()
+
+    assert fh.tell() == 0
+    while True:
+        data = fh.read(block_size)
+        checksummer.update(data)
+        if len(data) == 0:
+            calculated_checksum = checksummer.hexdigest()
+            if calculated_checksum != expected_sha256_checksum:
+                raise ChecksumValidationError(
+                    "calculated checksum ({}) does not match expected checksum ({})".format(
+                        calculated_checksum, expected_sha256_checksum))
+            break
+
+    fh.seek(0)

--- a/slicedimage/backends/_disk.py
+++ b/slicedimage/backends/_disk.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 
-from ._base import Backend
+from ._base import Backend, verify_checksum
 
 
 class DiskBackend(Backend):
@@ -24,6 +24,7 @@ class _FileLikeContextManager(object):
 
     def __enter__(self):
         self.handle = open(self.path, "rb")
+        verify_checksum(self.handle, self.checksum_sha256)
         return self.handle
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/slicedimage/backends/_http.py
+++ b/slicedimage/backends/_http.py
@@ -4,7 +4,7 @@ import requests
 from io import BytesIO
 
 from slicedimage.urlpath import pathjoin
-from ._base import Backend
+from ._base import Backend, verify_checksum
 
 
 class HttpBackend(Backend):
@@ -25,6 +25,7 @@ class _UrlContextManager(object):
     def __enter__(self):
         req = requests.get(self.url)
         self.handle = BytesIO(req.content)
+        verify_checksum(self.handle, self.checksum_sha256)
         return self.handle.__enter__()
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/tests/io/v0_0_0/test_disk_backend.py
+++ b/tests/io/v0_0_0/test_disk_backend.py
@@ -1,0 +1,80 @@
+import hashlib
+import json
+import os
+import unittest
+
+import numpy as np
+import skimage.io
+
+import slicedimage
+from slicedimage.backends import ChecksumValidationError
+from tests.utils import (
+    build_skeleton_manifest,
+    TemporaryDirectory,
+)
+
+
+class TestDiskBackend(unittest.TestCase):
+    def test_checksum_good(self):
+        self._test_checksum(True)
+
+    def test_checksum_bad(self):
+        self._test_checksum(False)
+
+    def _test_checksum(self, good):
+        """
+        Generate a tileset consisting of a single TIFF tile.  If the parameter `good` is True, then
+        we provide the correct checksum and verify loading works correctly.  Otherwise, we provide
+        the incorrect checksum and verify that loading raises an exception.
+        """
+        # write the tiff file
+        with TemporaryDirectory() as tempdir:
+            data = np.random.randint(0, 65535, size=(100, 100), dtype=np.uint16)
+            file_path = os.path.join(tempdir, "tile.tiff")
+            skimage.io.imsave(file_path, data, plugin="tifffile")
+            if good:
+                with open(file_path, "rb") as fh:
+                    checksum = hashlib.sha256(fh.read()).hexdigest()
+            else:
+                checksum = hashlib.sha256().hexdigest()
+
+            manifest = build_skeleton_manifest()
+            manifest['tiles'].append(
+                {
+                    "coordinates": {
+                        "x": [
+                            0.0,
+                            0.0001,
+                        ],
+                        "y": [
+                            0.0,
+                            0.0001,
+                        ]
+                    },
+                    "indices": {
+                        "hyb": 0,
+                        "ch": 0,
+                    },
+                    "file": "tile.tiff",
+                    "format": "tiff",
+                    "sha256": checksum,
+                },
+            )
+            with open(os.path.join(tempdir, "tileset.json"), "w") as fh:
+                fh.write(json.dumps(manifest))
+
+            result = slicedimage.Reader.parse_doc(
+                "tileset.json",
+                "file://{}".format(tempdir),
+                allow_caching=False,
+            )
+
+            if good:
+                self.assertTrue(np.array_equal(list(result.tiles())[0].numpy_array, data))
+            else:
+                with self.assertRaises(ChecksumValidationError):
+                    result.tiles()[0]._load()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
1. Added a `verify_checksum` method to the _base class.  It takes a handle, reads the data by chunk, and verifies the checksum.
2. Remove checksum validation from CacheBackend if we are populating the cache (assumption: the backend supplying the data should have validated the checksum.  However, we will now validate the data coming from the cache.
3. Ported the tests from #42.