### PR TITLE
enum34: remove dependency on py34+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 diskcache
-enum34
+enum34;python_version<"3.4"
 packaging
 numpy
 requests

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,18 @@
 
 import os
 import setuptools
+import sys
 
 install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(__file__), "requirements.txt"))]
 
+if sys.version_info >= (3, 4):
+    # Remove the dependency on enum34
+    # on platforms that have it natively.
+    install_requires.remove("enum34")
+
 setuptools.setup(
     name="slicedimage",
-    version="0.0.1",
+    version="0.0.2",
     description="Library to access sliced imaging data",
     author="Tony Tung",
     author_email="ttung@chanzuckerberg.com",

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,8 @@
 
 import os
 import setuptools
-import sys
 
 install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(__file__), "requirements.txt"))]
-
-if sys.version_info >= (3, 4):
-    # Remove the dependency on enum34
-    # on platforms that have it natively.
-    install_requires.remove("enum34")
 
 setuptools.setup(
     name="slicedimage",


### PR DESCRIPTION
For platforms that do not need enum34, conda packages
are not being built. As a part of getting starfish
built in bioconda, the enum34 dependency has been
disabled as an install dependency. pkg_resources'
load_entry_point however still assumes that enum34
is required due to setup.py and fails with:

```
pkg_resources.DistributionNotFound:
   The 'enum34' distribution was not found
   and is required by slicedimage
```

see:
 - https://github.com/spacetx/starfish/issues/44
 - https://github.com/bioconda/bioconda-recipes/pull/10637