### PR TITLE
Always calculate checksums when writing tiles.

### DIFF
--- a/slicedimage/io.py
+++ b/slicedimage/io.py
@@ -256,12 +256,8 @@ class v0_0_0(object):
                     }
 
                     with tile_opener(path, tile, ImageFormat.NUMPY.file_ext) as tile_fh:
-                        if tile.sha256 is None:
-                            hasher_fh = HashFile(hashlib.sha256)
-                            writer_fh = TeeWritableFileObject(tile_fh, hasher_fh)
-                        else:
-                            hasher_fh = None
-                            writer_fh = tile_fh
+                        hasher_fh = HashFile(hashlib.sha256)
+                        writer_fh = TeeWritableFileObject(tile_fh, hasher_fh)
                         tile_format = tile_writer(tile, writer_fh)
                         tiledoc[TileKeys.FILE] = os.path.basename(tile_fh.name)
                         if hasher_fh is not None:


### PR DESCRIPTION
The checksums attached to the tiles are the checksums at the time the tile is loaded.  It should not be used to write the tiles.

This should address the issue in this [comment](https://github.com/spacetx/starfish/issues/458#issuecomment-415213814)

Depends on #50 

Test plan: Add a test that writes a TIFF tileset, loads it back up, writes as a NUMPY tileset, and load that back up.  Without the change in slicedimage/io.py, it writes the checksum for the TIFF file and the load (and the test) fails.  With the change, the test passes.