### PR TITLE
Prevent cache pollution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(
 
 setuptools.setup(
     name="slicedimage",
-    version="0.0.3",
+    version="0.0.4",
     description="Library to access sliced imaging data",
     author="Tony Tung",
     author_email="ttung@chanzuckerberg.com",

--- a/slicedimage/backends/_caching.py
+++ b/slicedimage/backends/_caching.py
@@ -7,7 +7,7 @@ from diskcache import Cache
 from ._base import Backend, verify_checksum
 
 SIZE_LIMIT = 5e9
-CACHE_VERSION = "v0"
+CACHE_VERSION = "v1"
 
 
 class CachingBackend(Backend):
@@ -42,7 +42,8 @@ class _CachingBackendContextManager(object):
             file_data = self.cache.read(cache_key)
         except KeyError:
             # not in cache :(
-            with self.authoritative_backend.read_contextmanager(self.name) as sfh:
+            with self.authoritative_backend.read_contextmanager(
+                    self.name, self.checksum_sha256) as sfh:
                 file_data = sfh.read()
             self.cache.set(cache_key, file_data)
             self.handle = io.BytesIO(file_data)


### PR DESCRIPTION
Somehow, I made a mistake in merging my changes, and did not pass the checksum to the backend (I swear I ran into the same problem last time and fixed it already, but clearly it's not in the repo...).  To prevent repeating the mistake, I wrote a test to cover this case.

Bump the cache version to invalidate the caches with this bug.

Test plan: stashed the change to slicedimage/backends/_caching.py → test fails.