### PR TITLE
Re-add () to contextmanager call in _tile.py

### DIFF
--- a/slicedimage/_tile.py
+++ b/slicedimage/_tile.py
@@ -72,7 +72,7 @@ class Tile(object):
         """
         if self._source_fh_contextmanager is not None:
             assert self._numpy_array is None
-            with self._source_fh_contextmanager as src_fh:
+            with self._source_fh_contextmanager() as src_fh:
                 data = src_fh.read()
                 self._numpy_array = self.tile_format.reader_func(BytesIO(data))
                 dst_fh.write(data)


### PR DESCRIPTION
see: gh-40

I think this is leading to the failure from https://github.com/joshmoore/build-starfish/issues/1#issuecomment-416537231

```
Traceback (most recent call last):
  File "/home/starfish/.conda/envs/env/bin/starfish", line 11, in <module>
    sys.exit(starfish())
  File "/home/starfish/.conda/envs/env/lib/python3.7/site-packages/starfish/starfish.py", line 80, in starfish
    args.starfish_command(args, len(argv) != 0)
  File "/home/starfish/.conda/envs/env/lib/python3.7/site-packages/starfish/experiment/builder/cli.py", line 72, in run
    for aux_image_name in AUX_IMAGE_NAMES
  File "/home/starfish/.conda/envs/env/lib/python3.7/site-packages/starfish/experiment/builder/__init__.py", line 170, in write_experiment_json
    tile_writer=tile_writer,
  File "/home/starfish/.conda/envs/env/lib/python3.7/site-packages/slicedimage/io.py", line 117, in write_to_path
    partition, path, pretty, *args, **kwargs)
  File "/home/starfish/.conda/envs/env/lib/python3.7/site-packages/slicedimage/io.py", line 235, in generate_partition_document
    tile_writer=tile_writer
  File "/home/starfish/.conda/envs/env/lib/python3.7/site-packages/slicedimage/io.py", line 117, in write_to_path
    partition, path, pretty, *args, **kwargs)
  File "/home/starfish/.conda/envs/env/lib/python3.7/site-packages/slicedimage/io.py", line 261, in generate_partition_document
    tile_format = tile_writer(tile, writer_fh)
  File "/home/starfish/.conda/envs/env/lib/python3.7/site-packages/starfish/experiment/builder/__init__.py", line 38, in tile_writer
    tile.copy(fh)
  File "/home/starfish/.conda/envs/env/lib/python3.7/site-packages/slicedimage/_tile.py", line 75, in copy
    with self._source_fh_contextmanager as src_fh:
AttributeError: __enter__
```

