### PR TITLE
Reuse python diskcache instances

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(
 
 setuptools.setup(
     name="slicedimage",
-    version="0.0.4",
+    version="0.0.5",
     description="Library to access sliced imaging data",
     author="Tony Tung",
     author_email="ttung@chanzuckerberg.com",


### PR DESCRIPTION
Each instance holds open file handles, and each time we instantiate a backend, we rack up open file handles until we run out of them.

Test plan: Use this to successfully load the osmFISH data set in a python notebook.