### PR TITLE
Allow writing to non-numpy file formats.

### DIFF
--- a/slicedimage/_tile.py
+++ b/slicedimage/_tile.py
@@ -55,15 +55,13 @@ class Tile(object):
         self._numpy_array = None
         self.tile_format = tile_format
 
-    def write(self, dst_fh):
+    def write(self, dst_fh, tile_format):
         """
         Write the contents of this tile out to a given file handle.
         """
-        import numpy
-
         self._load()
 
-        numpy.save(dst_fh, self._numpy_array)
+        tile_format.writer_func(dst_fh, self._numpy_array)
 
     def copy(self, dst_fh):
         """

--- a/slicedimage/io.py
+++ b/slicedimage/io.py
@@ -142,9 +142,8 @@ class Writer(object):
         )
 
     @staticmethod
-    def default_tile_writer(tile, fh):
-        tile.write(fh)
-        return ImageFormat.NUMPY
+    def default_tile_writer(tile, fh, format):
+        tile.write(fh, format)
 
     def generate_partition_document(self, partition, path, pretty=False, *args, **kwargs):
         raise NotImplementedError()
@@ -220,7 +219,9 @@ class v0_0_0(object):
                 pretty=False,
                 partition_path_generator=Writer.default_partition_path_generator,
                 tile_opener=Writer.default_tile_opener,
-                tile_writer=Writer.default_tile_writer):
+                tile_writer=Writer.default_tile_writer,
+                tile_format=ImageFormat.NUMPY,
+        ):
             json_doc = {
                 CommonPartitionKeys.VERSION: v0_0_0.VERSION,
                 CommonPartitionKeys.EXTRAS: partition.extras,
@@ -256,9 +257,9 @@ class v0_0_0(object):
                         TileKeys.INDICES: tile.indices,
                     }
 
-                    with tile_opener(path, tile, ImageFormat.NUMPY.file_ext) as tile_fh:
+                    with tile_opener(path, tile, tile_format.file_ext) as tile_fh:
                         buffer_fh = BytesIO()
-                        tile_format = tile_writer(tile, buffer_fh)
+                        tile_writer(tile, buffer_fh, tile_format)
 
                         buffer_fh.seek(0)
                         tile.sha256 = hashlib.sha256(buffer_fh.getvalue()).hexdigest()


### PR DESCRIPTION
1. Adds a writer func to the ImageFormat class.
2. Instead of the tile writer callback dictating the file format, it now receives the requested file format and attempts to write it in that format.
3. Adds a test that writes out a TIFF set and reads it back.

Fixes https://github.com/spacetx/slicedimage/issues/2