### PR TITLE
Always represent coordinates internally as a range.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(
 
 setuptools.setup(
     name="slicedimage",
-    version="0.0.7",
+    version="0.1.0",
     description="Library to access sliced imaging data",
     author="Tony Tung",
     author_email="ttung@chanzuckerberg.com",

--- a/slicedimage/_tile.py
+++ b/slicedimage/_tile.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from ._formats import ImageFormat
-from ._typeformatting import format_tile_dimensions
+from ._typeformatting import format_tile_coordinates, format_tile_indices
 
 
 class Tile(object):
     def __init__(self, coordinates, indices, tile_shape=None, sha256=None, extras=None):
-        self.coordinates = format_tile_dimensions(coordinates)
-        self.indices = format_tile_dimensions(indices)
+        self.coordinates = format_tile_coordinates(coordinates)
+        self.indices = format_tile_indices(indices)
         self.tile_shape = tuple(tile_shape) if tile_shape is not None else None
         self.sha256 = sha256
         self.extras = {} if extras is None else extras

--- a/slicedimage/_typeformatting.py
+++ b/slicedimage/_typeformatting.py
@@ -1,20 +1,39 @@
 import enum
 
 
-def format_tile_dimensions(tile_dimensions):
+def format_tile_coordinates(tile_dimensions):
     """
     Given a dictionary mapping keys to values, where the keys may either be strings or enums, and
-    the values may either be iterables or not, return a new dictionary with the same contents,
-    except the keys are converted to strings and the values that are iterables are converted to
-    tuples.
+    the values may either be a scalar number or an iterable of two scalar numbers, return a new
+    dictionary with the same contents, except the keys are converted to strings, and the value is
+    transformed as per the following rules:
+
+    scalar_number -> (scalar_number, scalar_number)
+    [scalar_number_0, scalar_number_1] -> (scalar_number_0, scalar_number_1)
     """
     result = dict()
     for name, value in tile_dimensions.items():
+        key = _str_or_enum_to_str(name)
         try:
             iter(value)
-            result[_str_or_enum_to_str(name)] = tuple(value)
+            value = tuple(value)
+            if len(value) == 2:
+                result[key] = value
+            else:
+                raise ValueError("Not a valid input")
         except TypeError:
-            result[_str_or_enum_to_str(name)] = _str_or_enum_to_str(value)
+            result[key] = (value, value)
+    return result
+
+
+def format_tile_indices(tile_dimensions):
+    """
+    Given a dictionary mapping keys to values, where the keys may either be strings or enums,
+    return a new dictionary with the same contents, except the keys are converted to strings.
+    """
+    result = dict()
+    for name, value in tile_dimensions.items():
+        result[_str_or_enum_to_str(name)] = value
     return result
 
 

--- a/tests/test_tile_coordinates.py
+++ b/tests/test_tile_coordinates.py
@@ -1,0 +1,54 @@
+import unittest
+
+from slicedimage import Tile
+
+
+class TestTileCoordinates(unittest.TestCase):
+    def test_tuple_to_tuple(self):
+        tile = Tile(
+            {
+                'coord': (0, 1),
+            },
+            {},
+        )
+        self.assertEqual(tile.coordinates['coord'], (0, 1))
+
+    def test_list_to_tuple(self):
+        tile = Tile(
+            {
+                'coord': [0, 1],
+            },
+            {},
+        )
+        self.assertEqual(tile.coordinates['coord'], (0, 1))
+
+    def test_scalar_to_tuple(self):
+        tile = Tile(
+            {
+                'coord': 0,
+            },
+            {},
+        )
+        self.assertEqual(tile.coordinates['coord'], (0, 0))
+
+    def test_single_scalar_in_tuple(self):
+        with self.assertRaises(ValueError):
+            Tile(
+                {
+                    'coord': (0,),
+                },
+                {},
+            )
+
+    def test_long_tuple(self):
+        with self.assertRaises(ValueError):
+            Tile(
+                {
+                    'coord': (0, 1, 2),
+                },
+                {},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
If the input is a range, keep it a range.  If it's a scalar value, transform it into (scalar value, scalar value).

Bump version to 0.1.0 to reflect that the API has changed.

Test plan: wrote tests detailing the various possible inputs.