### PR TITLE
Add a numpy-array-future data source for tiles.

### DIFF
--- a/slicedimage/_tile.py
+++ b/slicedimage/_tile.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from ._formats import ImageFormat
 from ._typeformatting import format_tile_coordinates, format_tile_indices
 
 
@@ -12,19 +11,15 @@ class Tile(object):
         self.sha256 = sha256
         self.extras = {} if extras is None else extras
 
-        self.tile_format = None
-        self._source_fh_contextmanager = None
         self._numpy_array = None
-        self._name_or_url = None
+        self._numpy_array_future = None
 
     def _load(self):
-        if self._source_fh_contextmanager is not None:
-            assert self._numpy_array is None, ("Inconsistent state.  Tile should only have one "
-                                               "data source.")
-            with self._source_fh_contextmanager as src_fh:
-                self._numpy_array = self.tile_format.reader_func(src_fh)
-            self._source_fh_contextmanager = None
-            self.tile_format = ImageFormat.NUMPY
+        if self._numpy_array_future is not None:
+            assert self._numpy_array is None, (
+                "Inconsistent state.  Tile should only have one data source.")
+            self._numpy_array = self._numpy_array_future()
+            self._numpy_array_future = None
             self.tile_shape = self.numpy_array.shape
 
     @property
@@ -37,21 +32,22 @@ class Tile(object):
         if self.tile_shape is not None:
             assert self.tile_shape == numpy_array.shape
 
-        self._source_fh_contextmanager = None
         self._numpy_array = numpy_array
-        self.tile_format = ImageFormat.NUMPY
         self.tile_shape = self._numpy_array.shape
+        self._numpy_array_future = None
 
-    def set_source_fh_contextmanager(self, source_fh_contextmanager, tile_format):
+    def set_numpy_array_future(self, future):
         """
-        Provides a tile with a callable, which should yield a context manager that returns a
-        file-like object.  If the  tile data is requested, the context manager is invoked and the
-        data is read from the returned file-like object.  It is possible that the context manager is
-        never invoked.
+        Provides a tile with a callable, which should return the tile data when invoked.  It is
+        possible that the future is never invoked.
+
+        Parameters
+        ----------
+        future : Callable[[], np.ndarray]
+            A callable that yields the tile data when invoked.
         """
-        self._source_fh_contextmanager = source_fh_contextmanager
+        self._numpy_array_future = future
         self._numpy_array = None
-        self.tile_format = tile_format
 
     def write(self, dst_fh, tile_format):
         """


### PR DESCRIPTION
Currently, if we want to use a future to provide image data for a tile, we have to wrap it in a BytesIO object and then use `set_source_fh_contextmanager`.  This removes the necessity for wrapping.

We need to use this interface to load data into memory more selectively, rather than all at once.

Test plan: `make -j test`