### PR TITLE
Simplify the tests

### DIFF
--- a/tests/io/v0_0_0/test_disk_backend.py
+++ b/tests/io/v0_0_0/test_disk_backend.py
@@ -1,79 +1,52 @@
+import contextlib
 import hashlib
-import json
 import os
+import tempfile
 import unittest
 
-import numpy as np
-import skimage.io
-
-import slicedimage
-from slicedimage.backends import ChecksumValidationError
-from tests.utils import (
-    build_skeleton_manifest,
-    TemporaryDirectory,
-)
+from slicedimage.backends import ChecksumValidationError, DiskBackend
 
 
 class TestDiskBackend(unittest.TestCase):
     def test_checksum_good(self):
-        self._test_checksum(True)
+        with self._test_checksum_setup() as setupdata:
+            filepath, data, expected_checksum = setupdata
+
+            backend = DiskBackend(os.path.dirname(filepath))
+            with backend.read_contextmanager(os.path.basename(filepath), expected_checksum) as cm:
+                self.assertEqual(cm.read(), data)
 
     def test_checksum_bad(self):
-        self._test_checksum(False)
+        with self._test_checksum_setup() as setupdata:
+            filepath, data, expected_checksum = setupdata
 
-    def _test_checksum(self, good):
+            # make the hash incorrect
+            expected_checksum = "{:x}".format(int(hashlib.sha256().hexdigest(), 16) + 1)
+
+            backend = DiskBackend(os.path.dirname(filepath))
+            with self.assertRaises(ChecksumValidationError):
+                with backend.read_contextmanager(
+                        os.path.basename(filepath),
+                        expected_checksum) as cm:
+                    self.assertEqual(cm.read(), data)
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _test_checksum_setup():
         """
-        Generate a tileset consisting of a single TIFF tile.  If the parameter `good` is True, then
-        we provide the correct checksum and verify loading works correctly.  Otherwise, we provide
-        the incorrect checksum and verify that loading raises an exception.
+        Write some random data to a temporary file and yield its path, the data, and the checksum of
+        the data.
         """
-        # write the tiff file
-        with TemporaryDirectory() as tempdir:
-            data = np.random.randint(0, 65535, size=(100, 100), dtype=np.uint16)
-            file_path = os.path.join(tempdir, "tile.tiff")
-            skimage.io.imsave(file_path, data, plugin="tifffile")
-            if good:
-                with open(file_path, "rb") as fh:
-                    checksum = hashlib.sha256(fh.read()).hexdigest()
-            else:
-                checksum = hashlib.sha256().hexdigest()
+        # write the file
+        data = os.urandom(1024)
 
-            manifest = build_skeleton_manifest()
-            manifest['tiles'].append(
-                {
-                    "coordinates": {
-                        "x": [
-                            0.0,
-                            0.0001,
-                        ],
-                        "y": [
-                            0.0,
-                            0.0001,
-                        ]
-                    },
-                    "indices": {
-                        "hyb": 0,
-                        "ch": 0,
-                    },
-                    "file": "tile.tiff",
-                    "format": "tiff",
-                    "sha256": checksum,
-                },
-            )
-            with open(os.path.join(tempdir, "tileset.json"), "w") as fh:
-                fh.write(json.dumps(manifest))
+        expected_checksum = hashlib.sha256(data).hexdigest()
 
-            result = slicedimage.Reader.parse_doc(
-                "tileset.json",
-                "file://{}".format(tempdir),
-                allow_caching=False,
-            )
+        with tempfile.NamedTemporaryFile() as tfh:
+            tfh.write(data)
+            tfh.flush()
 
-            if good:
-                self.assertTrue(np.array_equal(list(result.tiles())[0].numpy_array, data))
-            else:
-                with self.assertRaises(ChecksumValidationError):
-                    result.tiles()[0]._load()
+            yield tfh.name, data, expected_checksum
 
 
 if __name__ == "__main__":

--- a/tests/io/v0_0_0/test_reader.py
+++ b/tests/io/v0_0_0/test_reader.py
@@ -1,9 +1,13 @@
 import collections
+import json
 import os
 import unittest
 
-import slicedimage
+import numpy as np
+import skimage.io
 
+import slicedimage
+from tests.utils import build_skeleton_manifest, TemporaryDirectory
 
 baseurl = "file://{}".format(os.path.abspath(os.path.dirname(__file__)))
 
@@ -46,3 +50,88 @@ class TestReader(unittest.TestCase):
                 self.assertTrue(isinstance(value, collections.Hashable))
             for value in tile.indices.values():
                 self.assertTrue(isinstance(value, collections.Hashable))
+
+
+class TestFormats(unittest.TestCase):
+    def test_tiff(self):
+        """
+        Generate a tileset consisting of a single TIFF tile, and then read it.
+        """
+        with TemporaryDirectory() as tempdir:
+            # write the tiff file
+            data = np.random.randint(0, 65535, size=(100, 100), dtype=np.uint16)
+            skimage.io.imsave(os.path.join(tempdir, "tile.tiff"), data, plugin="tifffile")
+
+            # TODO: (ttung) We should really be producing a tileset programmatically and writing it
+            # disk.  However, our current write path only produces numpy output files.
+            manifest = build_skeleton_manifest()
+            manifest['tiles'].append(
+                {
+                    "coordinates": {
+                        "x": [
+                            0.0,
+                            0.0001,
+                        ],
+                        "y": [
+                            0.0,
+                            0.0001,
+                        ]
+                    },
+                    "indices": {
+                        "hyb": 0,
+                        "ch": 0,
+                    },
+                    "file": "tile.tiff",
+                    "format": "tiff",
+                },
+            )
+            with open(os.path.join(tempdir, "tileset.json"), "w") as fh:
+                fh.write(json.dumps(manifest))
+
+            result = slicedimage.Reader.parse_doc(
+                "tileset.json",
+                "file://{}".format(tempdir),
+            )
+
+            self.assertTrue(np.array_equal(list(result.tiles())[0].numpy_array, data))
+
+    def test_numpy(self):
+        """
+        Generate a tileset consisting of a single TIFF tile, and then read it.
+        """
+        image = slicedimage.TileSet(
+            ["x", "y", "ch", "hyb"],
+            {'ch': 1, 'hyb': 1},
+            (100, 100),
+        )
+
+        tile = slicedimage.Tile(
+            {
+                'x': (0.0, 0.01),
+                'y': (0.0, 0.01),
+            },
+            {
+                'hyb': 0,
+                'ch': 0,
+            },
+        )
+        tile.numpy_array = np.random.randint(0, 65535, size=(100, 100), dtype=np.uint16)
+        image.add_tile(tile)
+
+        with TemporaryDirectory() as tempdir:
+            partition_path = os.path.join(tempdir, "tileset.json")
+            partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
+                image, partition_path)
+            with open(partition_path, "w") as fh:
+                json.dump(partition_doc, fh)
+
+            result = slicedimage.Reader.parse_doc(
+                "tileset.json",
+                "file://{}".format(tempdir),
+            )
+
+            self.assertTrue(np.array_equal(list(result.tiles())[0].numpy_array, tile.numpy_array))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
1. Each of the backend tests simply test the retrieval of a single file.
2. Moved the complex tiff / numpy tests to test_reader.py where they belong.

Test plan: run all the tests.