### PR TITLE
Explicitly spell out the contract for read_contextmanager

### DIFF
--- a/slicedimage/backends/_base.py
+++ b/slicedimage/backends/_base.py
@@ -5,6 +5,22 @@ import hashlib
 
 class Backend(object):
     def read_contextmanager(self, name, checksum_sha256=None):
+        """
+        Returns a context manager, that when entered, should return a file-like object that can be
+        read to get the data.
+
+        It is possible to enter the context manager multiple times to yield the same data.
+
+        If the checksum is provided and it does not match the checksum of the data read,
+        ChecksumValidationError will be raised.
+
+        Parameters
+        ----------
+        name : str
+            The name of the file that is to be read.
+        checksum_sha256 : Optional[str]
+            The expected checksum of the file.
+        """
         raise NotImplementedError()
 
     def write_file_handle(self, name):

--- a/tests/io/v0_0_0/test_caching_backend.py
+++ b/tests/io/v0_0_0/test_caching_backend.py
@@ -109,6 +109,20 @@ class TestCachingBackend(unittest.TestCase):
             with self.caching_backend.read_contextmanager(filename, expected_checksum) as cm:
                 self.assertEqual(cm.read(), data)
 
+    def test_reentrant(self):
+        with self._test_checksum_setup(self.tempdir.name) as setupdata:
+            filename, data, expected_checksum = setupdata
+
+            with self.caching_backend.read_contextmanager(filename, expected_checksum) as cm0:
+                data0 = cm0.read(1)
+                with self.caching_backend.read_contextmanager(filename, expected_checksum) as cm1:
+                    data1 = cm1.read()
+
+                data0 = data0 + cm0.read()
+
+                self.assertEqual(data, data0)
+                self.assertEqual(data, data1)
+
     @staticmethod
     @contextlib.contextmanager
     def _test_checksum_setup(tempdir):

--- a/tests/io/v0_0_0/test_disk_backend.py
+++ b/tests/io/v0_0_0/test_disk_backend.py
@@ -30,6 +30,23 @@ class TestDiskBackend(unittest.TestCase):
                         expected_checksum) as cm:
                     self.assertEqual(cm.read(), data)
 
+    def test_reentrant(self):
+        with self._test_checksum_setup() as setupdata:
+            filepath, data, expected_checksum = setupdata
+
+            backend = DiskBackend(os.path.dirname(filepath))
+            with backend.read_contextmanager(os.path.basename(filepath), expected_checksum) as cm0:
+                data0 = cm0.read(1)
+                with backend.read_contextmanager(
+                        os.path.basename(filepath),
+                        expected_checksum) as cm1:
+                    data1 = cm1.read()
+
+                data0 = data0 + cm0.read()
+
+                self.assertEqual(data, data0)
+                self.assertEqual(data, data1)
+
     @staticmethod
     @contextlib.contextmanager
     def _test_checksum_setup():

--- a/tests/io/v0_0_0/test_http_backend.py
+++ b/tests/io/v0_0_0/test_http_backend.py
@@ -74,6 +74,20 @@ class TestHttpBackend(unittest.TestCase):
                 with self.http_backend.read_contextmanager(filename, expected_checksum) as cm:
                     self.assertEqual(cm.read(), data)
 
+    def test_reentrant(self):
+        with self._test_checksum_setup(self.tempdir.name) as setupdata:
+            filename, data, expected_checksum = setupdata
+
+            with self.http_backend.read_contextmanager(filename, expected_checksum) as cm0:
+                data0 = cm0.read(1)
+                with self.http_backend.read_contextmanager(filename, expected_checksum) as cm1:
+                    data1 = cm1.read()
+
+                data0 = data0 + cm0.read()
+
+                self.assertEqual(data, data0)
+                self.assertEqual(data, data1)
+
     @staticmethod
     @contextlib.contextmanager
     def _test_checksum_setup(tempdir):


### PR DESCRIPTION
1. Add documentation.
2. Add expectation that it should be possible to invoke the context manager multiple times.
3. Add tests for reentrancy.

Depends on #68, #70 