### PR TITLE
Record the tile shape in our data structures if it's not provided.

### DIFF
--- a/tests/io/v0_0_0/test_missing_shape.py
+++ b/tests/io/v0_0_0/test_missing_shape.py
@@ -1,0 +1,75 @@
+import codecs
+import json
+import os
+import tempfile
+import unittest
+import warnings
+
+import numpy as np
+
+import slicedimage
+from slicedimage.io import TileKeys, TileSetKeys
+from tests.utils import TemporaryDirectory
+
+baseurl = "file://{}".format(os.path.abspath(os.path.dirname(__file__)))
+
+
+class TestWrite(unittest.TestCase):
+    def test_tileset_without_shapes(self):
+        image = slicedimage.TileSet(
+            ["x", "y", "ch", "hyb"],
+            {'ch': 2, 'hyb': 2},
+        )
+
+        for hyb in range(2):
+            for ch in range(2):
+                tile = slicedimage.Tile(
+                    {
+                        'x': (0.0, 0.01),
+                        'y': (0.0, 0.01),
+                    },
+                    {
+                        'hyb': hyb,
+                        'ch': ch,
+                    },
+                )
+                tile.numpy_array = np.zeros((100, 100))
+                tile.numpy_array[hyb, ch] = 1
+                image.add_tile(tile)
+
+        with TemporaryDirectory() as tempdir, \
+                tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
+            partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
+                image, partition_file.name)
+
+            # remove the shape information from the tiles.
+            for tile in partition_doc[TileSetKeys.TILES]:
+                del tile[TileKeys.TILE_SHAPE]
+
+            writer = codecs.getwriter("utf-8")
+            json.dump(partition_doc, writer(partition_file))
+            partition_file.flush()
+
+            basename = os.path.basename(partition_file.name)
+            baseurl = "file://{}".format(os.path.dirname(partition_file.name))
+
+            loaded = slicedimage.Reader.parse_doc(basename, baseurl)
+
+            for hyb in range(2):
+                for ch in range(2):
+                    tiles = [_tile
+                             for _tile in loaded.tiles(
+                                 lambda tile: (tile.indices['hyb'] == hyb and
+                                               tile.indices['ch'] == ch))]
+
+                    self.assertEqual(len(tiles), 1)
+                    with warnings.catch_warnings(record=True) as w:
+                        # Cause all warnings to always be triggered.  Duplicate warnings are
+                        # normally suppressed.
+                        warnings.simplefilter("always")
+
+                        tile_shape = tiles[0].tile_shape
+
+                        self.assertEqual(tile_shape, (100, 100))
+                        self.assertEqual(len(w), 1)
+                        self.assertIn("Decoding tile just to obtain shape", str(w[0].message))


### PR DESCRIPTION
If the tile_shape is not provided by the json file, we should infer it from the actual data.  This is a suboptimal data path since it requires a decoding step just to get the shape of the tile, so we warn about it.

Previously, this field was set by `_load()`, but that was removed in #72.

Test plan: Generate a tileset document, and then strip the shape data from the tiles.  Then read it back.  The correct tile shapes should be provided, but getting them should trigger a warning.