### PR TITLE
Add __repr__ to TileSet

### DIFF
--- a/slicedimage/_tileset.py
+++ b/slicedimage/_tileset.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-
 from ._typeformatting import format_tileset_dimensions, format_tileset_shape
 
 
@@ -20,6 +19,41 @@ class TileSet(object):
         self._tiles = []
 
         self._discrete_dimensions = set()
+
+    def __repr__(self):
+        # get dimensions of optional shapes
+        attributes = [
+            "{k}: {v}".format(k=k, v=self.shape[k])
+            for k in self.dimensions - {'y', 'x'}
+        ]
+        xmin, xmax, ymin, ymax = float("inf"), float("-inf"), float("inf"), float("-inf")
+        for tile in self._tiles:
+            # try to get the shape in the following order:
+            # 1. read the tile's declared shape without forcing a read & decode of the tile data.
+            # 2. read the tileset's default tile shape.
+            # 3. read the tile's shape through a read & decode.
+            shape = tile._tile_shape
+            if shape is None:
+                shape = self.default_tile_shape
+            if shape is None:
+                shape = tile.tile_shape
+
+            xmin = min(xmin, shape[0])
+            xmax = max(xmax, shape[0])
+            ymin = min(ymin, shape[1])
+            ymax = max(ymax, shape[1])
+
+        if xmin == xmax:
+            attributes.append("x: {}".format(xmin))
+        else:
+            attributes.append("x: ({}-{})".format(xmin, xmax))
+        if ymin == ymax:
+            attributes.append("y: {}".format(ymin))
+        else:
+            attributes.append("y: ({}-{})".format(ymin, ymax))
+
+        shape = ", ".join(attributes)
+        return "<slicedimage.TileSet ({shape})>".format(shape=shape)
 
     def validate(self):
         raise NotImplementedError()


### PR DESCRIPTION
Obtain the tile shape through:
  1. read the tile's declared shape without forcing a read & decode of the tile data.
  2. read the tileset's default tile shape.
  3. read the tile's shape through a read & decode.

Print the range of tile sizes, if it's a variety of values, or a scalar if all the tiles are the same size.

This is a continuation of #57.

Test plan:

```
<starfish.Experiment (FOVs=1)>
{
fov_001: <starfish.FieldOfView>
  Primary Image: <starfish.ImageStack (r: 4, c: 4, z: 1, y: 1044, x: 1390)>
  Auxiliary Images:
    nuclei: <slicedimage.TileSet (r: 1, c: 1, x: 1044, y: 1390)>
    dots: <slicedimage.TileSet (r: 1, c: 1, x: 1044, y: 1390)>
}
```