### PR TITLE
Accept coordinate arrays of size 1

### DIFF
--- a/slicedimage/_typeformatting.py
+++ b/slicedimage/_typeformatting.py
@@ -17,7 +17,9 @@ def format_tile_coordinates(tile_dimensions):
         try:
             iter(value)
             value = tuple(value)
-            if len(value) == 2:
+            if len(value) == 1:
+                result[key] = (value[0], value[0])
+            elif len(value) == 2:
                 result[key] = value
             else:
                 raise ValueError("Not a valid input")

--- a/tests/test_tile_coordinates.py
+++ b/tests/test_tile_coordinates.py
@@ -31,14 +31,14 @@ class TestTileCoordinates(unittest.TestCase):
         )
         self.assertEqual(tile.coordinates['coord'], (0, 0))
 
-    def test_single_scalar_in_tuple(self):
-        with self.assertRaises(ValueError):
-            Tile(
-                {
-                    'coord': (0,),
-                },
-                {},
-            )
+    def test_single_scalar_to_tuple(self):
+        tile = Tile(
+            {
+                'coord': (0,),
+            },
+            {},
+        )
+        self.assertEqual(tile.coordinates['coord'], (0, 0))
 
     def test_long_tuple(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
The format states:

```
    "xc": {
      "type": "array",
      "minItems": 1,
      "maxItems": 2,
```

suggesting that a coordinate of length one will be accepted. For the
moment, this loosens the `slicedimage` restriction to allow for either
a scalar or an array of size 1 or 2 until the two can be unified.