### PR TITLE
Propagate tile_format for multi-level images

### DIFF
--- a/slicedimage/io.py
+++ b/slicedimage/io.py
@@ -237,6 +237,7 @@ class v0_0_0(object):
                         partition, partition_path, pretty,
                         partition_path_generator=partition_path_generator,
                         tile_opener=tile_opener,
+                        tile_format=tile_format,
                     )
                     json_doc[CollectionKeys.CONTENTS][partition_name] = os.path.basename(
                         partition_path)


### PR DESCRIPTION
Currently, the tile format is correctly set when we write a TileSet.  If we writte a Collection, the tile format needs to be propagated to the lower level write calls.

Test plan:
```
[tt (.venv)]:~/microscopy/starfish:master> python examples/get_iss_breast_data.py /Users/ttung/Downloads/starfish_data/mignardi_breast_1/raw/ ../starfish-formatted-data/breast/ 1
[tt (.venv)]:~/microscopy/starfish:master> file ../starfish-formatted-data/breast/primary_image-fov_000-Z0-H0-C0.tiff
../starfish-formatted-data/breast/primary_image-fov_000-Z0-H0-C0.tiff: TIFF image data, little-endian, direntries=14, height=1044, bps=16, compression=none, PhotometricIntepretation=BlackIsZero, description={"shape": [1044, 1390]}, width=1390
```