### PR TITLE
Prevent exception in repr(..)

### DIFF
--- a/slicedimage/_tileset.py
+++ b/slicedimage/_tileset.py
@@ -25,6 +25,7 @@ class TileSet(object):
         attributes = [
             "{k}: {v}".format(k=k, v=self.shape[k])
             for k in self.dimensions - {'y', 'x'}
+            if k in self.shape
         ]
         xmin, xmax, ymin, ymax = float("inf"), float("-inf"), float("inf"), float("-inf")
         for tile in self._tiles:


### PR DESCRIPTION
Coordinates in geometric space are not part of the non-geometric shape, so don't try reading them.

Test plan: repr(..) on the seqfish TileSet.