### PR TITLE
Fix ordering of tile pixel dimensions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ dimensions           list    Yes       Names of the dimensions.  Dimensions must
 tiles                dict    Yes       See Tiles_
 shape                dict    Yes       Maps each non-geometric dimension to the possible number of values for that
                                        dimension for the tiles in this `Tile Set`_.
-default_tile_shape   tuple   No        Default pixel dimensions of a tile, ordered as x, y.
+default_tile_shape   tuple   No        Default pixel dimensions of a tile, ordered as y, x.
 default_tile_format  string  No        Default file format of the tiles.
 zoom                 dict    No        See Zoom_
 extras               dict    No        Additional application-specific payload.  The vocabulary and the schema are
@@ -89,7 +89,7 @@ indices       dict    Yes       Maps each of the dimensions *not* in geometric s
                                 of the dimensions here must be specified in the `Tile Set`_.  The values of the indices
                                 must be non-negative integers, and every value up to but not including the maximum
                                 specified in the `shape` field of the `Tile Set`_ must be represented.
-tile_shape    tuple   No        Pixel dimensions of a tile, ordered as x, y.  If this is not provided, it defaults to
+tile_shape    tuple   No        Pixel dimensions of a tile, ordered as y, x.  If this is not provided, it defaults to
                                 `default_tile_shape` in the `Tile Set`_).  If neither is provided, the tile shape is
                                 inferred from actual file.
 tile_format   string  No        File format of the tile.  If this is not provided, it defaults to `default_tile_format`

--- a/tests/io/v0_0_0/test_missing_shape.py
+++ b/tests/io/v0_0_0/test_missing_shape.py
@@ -33,7 +33,7 @@ class TestWrite(unittest.TestCase):
                         'ch': ch,
                     },
                 )
-                tile.numpy_array = np.zeros((100, 100))
+                tile.numpy_array = np.zeros((120, 80))
                 tile.numpy_array[hyb, ch] = 1
                 image.add_tile(tile)
 
@@ -70,6 +70,6 @@ class TestWrite(unittest.TestCase):
 
                         tile_shape = tiles[0].tile_shape
 
-                        self.assertEqual(tile_shape, (100, 100))
+                        self.assertEqual(tile_shape, (120, 80))
                         self.assertEqual(len(w), 1)
                         self.assertIn("Decoding tile just to obtain shape", str(w[0].message))

--- a/tests/io/v0_0_0/test_reader.py
+++ b/tests/io/v0_0_0/test_reader.py
@@ -59,7 +59,7 @@ class TestFormats(unittest.TestCase):
         """
         with TemporaryDirectory() as tempdir:
             # write the tiff file
-            data = np.random.randint(0, 65535, size=(100, 100), dtype=np.uint16)
+            data = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
             skimage.io.imsave(os.path.join(tempdir, "tile.tiff"), data, plugin="tifffile")
 
             # TODO: (ttung) We should really be producing a tileset programmatically and writing it
@@ -102,7 +102,7 @@ class TestFormats(unittest.TestCase):
         image = slicedimage.TileSet(
             ["x", "y", "ch", "hyb"],
             {'ch': 1, 'hyb': 1},
-            (100, 100),
+            (120, 80),
         )
 
         tile = slicedimage.Tile(
@@ -115,7 +115,7 @@ class TestFormats(unittest.TestCase):
                 'ch': 0,
             },
         )
-        tile.numpy_array = np.random.randint(0, 65535, size=(100, 100), dtype=np.uint16)
+        tile.numpy_array = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
         image.add_tile(tile)
 
         with TemporaryDirectory() as tempdir:

--- a/tests/io/v0_0_0/test_write.py
+++ b/tests/io/v0_0_0/test_write.py
@@ -20,7 +20,7 @@ class TestWrite(unittest.TestCase):
         image = slicedimage.TileSet(
             ["x", "y", "ch", "hyb"],
             {'ch': 2, 'hyb': 2},
-            (100, 100),
+            (120, 80),
         )
 
         for hyb in range(2):
@@ -35,7 +35,7 @@ class TestWrite(unittest.TestCase):
                         'ch': ch,
                     },
                 )
-                tile.numpy_array = np.zeros((100, 100))
+                tile.numpy_array = np.zeros((120, 80))
                 tile.numpy_array[hyb, ch] = 1
                 image.add_tile(tile)
 
@@ -71,7 +71,7 @@ class TestWrite(unittest.TestCase):
         image = slicedimage.TileSet(
             ["x", "y", "ch", "hyb"],
             {'ch': 2, 'hyb': 2},
-            (100, 100),
+            (120, 80),
         )
 
         for hyb in range(2):
@@ -86,7 +86,7 @@ class TestWrite(unittest.TestCase):
                         'ch': ch,
                     },
                 )
-                tile.numpy_array = np.zeros((100, 100))
+                tile.numpy_array = np.zeros((120, 80))
                 tile.numpy_array[hyb, ch] = 1
                 image.add_tile(tile)
         collection = slicedimage.Collection()
@@ -128,7 +128,7 @@ class TestWrite(unittest.TestCase):
         """
         # write the tiff file
         with TemporaryDirectory() as tempdir:
-            data = np.random.randint(0, 65535, size=(100, 100), dtype=np.uint16)
+            data = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
             file_path = os.path.join(tempdir, "tile.tiff")
             skimage.io.imsave(file_path, data, plugin="tifffile")
             with open(file_path, "rb") as fh:
@@ -186,7 +186,7 @@ class TestWrite(unittest.TestCase):
         image = slicedimage.TileSet(
             dimensions=["x", "y", "ch", "hyb"],
             shape={'ch': 2, 'hyb': 2},
-            default_tile_shape=(100, 100),
+            default_tile_shape=(120, 80),
         )
 
         for hyb in range(2):
@@ -201,7 +201,7 @@ class TestWrite(unittest.TestCase):
                         'ch': ch,
                     },
                 )
-                tile.numpy_array = np.zeros((100, 100), dtype=np.uint32)
+                tile.numpy_array = np.zeros((120, 80), dtype=np.uint32)
                 tile.numpy_array[hyb, ch] = 1
                 image.add_tile(tile)
 
@@ -229,8 +229,12 @@ class TestWrite(unittest.TestCase):
 
                     self.assertEqual(len(tiles), 1)
 
-                    expected = np.zeros((100, 100), dtype=np.uint32)
+                    expected = np.zeros((120, 80), dtype=np.uint32)
                     expected[hyb, ch] = 1
 
                     self.assertEqual(tiles[0].numpy_array.all(), expected.all())
                     self.assertIsNotNone(tiles[0].sha256)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
It should be y, x.

Adjusted the tests to catch future misinterpretations of the ordering of tile_shape.

This is part of the resolution for https://github.com/spacetx/starfish/issues/528.
