### PR TITLE
[easy] Drop python 3.4 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
 - 2.7
-- 3.4
 - 3.5
 - 3.6
 dist: trusty


### PR DESCRIPTION
It seems to be choking on travis consistently.