### PR TITLE
reformat existing usages of 'x' and 'y'

### DIFF
--- a/tests/io/v0_0_0/test_missing_shape.py
+++ b/tests/io/v0_0_0/test_missing_shape.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 
 import slicedimage
+from slicedimage._dimensions import DimensionNames
 from slicedimage.io import TileKeys, TileSetKeys
 from tests.utils import TemporaryDirectory
 
@@ -17,7 +18,7 @@ baseurl = "file://{}".format(os.path.abspath(os.path.dirname(__file__)))
 class TestMissingShape(unittest.TestCase):
     def test_tileset_without_shapes(self):
         image = slicedimage.TileSet(
-            ["x", "y", "ch", "hyb"],
+            [DimensionNames.X, DimensionNames.Y, "ch", "hyb"],
             {'ch': 2, 'hyb': 2},
         )
 
@@ -25,8 +26,8 @@ class TestMissingShape(unittest.TestCase):
             for ch in range(2):
                 tile = slicedimage.Tile(
                     {
-                        'x': (0.0, 0.01),
-                        'y': (0.0, 0.01),
+                        DimensionNames.X: (0.0, 0.01),
+                        DimensionNames.Y: (0.0, 0.01),
                     },
                     {
                         'hyb': hyb,
@@ -70,6 +71,6 @@ class TestMissingShape(unittest.TestCase):
 
                         tile_shape = tiles[0].tile_shape
 
-                        self.assertEqual(tile_shape, {'y': 120, 'x': 80})
+                        self.assertEqual(tile_shape, {DimensionNames.Y: 120, DimensionNames.X: 80})
                         self.assertEqual(len(w), 1)
                         self.assertIn("Decoding tile just to obtain shape", str(w[0].message))

--- a/tests/io/v0_0_0/test_reader.py
+++ b/tests/io/v0_0_0/test_reader.py
@@ -7,6 +7,7 @@ import numpy as np
 import skimage.io
 
 import slicedimage
+from slicedimage._dimensions import DimensionNames
 from tests.utils import build_skeleton_manifest, TemporaryDirectory
 
 baseurl = "file://{}".format(os.path.abspath(os.path.dirname(__file__)))
@@ -68,11 +69,11 @@ class TestFormats(unittest.TestCase):
             manifest['tiles'].append(
                 {
                     "coordinates": {
-                        "x": [
+                        DimensionNames.X.value: [
                             0.0,
                             0.0001,
                         ],
-                        "y": [
+                        DimensionNames.Y.value: [
                             0.0,
                             0.0001,
                         ]
@@ -100,15 +101,15 @@ class TestFormats(unittest.TestCase):
         Generate a tileset consisting of a single TIFF tile, and then read it.
         """
         image = slicedimage.TileSet(
-            ["x", "y", "ch", "hyb"],
+            [DimensionNames.X, DimensionNames.Y, "ch", "hyb"],
             {'ch': 1, 'hyb': 1},
-            {'y': 120, 'x': 80},
+            {DimensionNames.Y: 120, DimensionNames.X: 80},
         )
 
         tile = slicedimage.Tile(
             {
-                'x': (0.0, 0.01),
-                'y': (0.0, 0.01),
+                DimensionNames.X: (0.0, 0.01),
+                DimensionNames.Y: (0.0, 0.01),
             },
             {
                 'hyb': 0,

--- a/tests/io/v0_0_0/test_write.py
+++ b/tests/io/v0_0_0/test_write.py
@@ -10,6 +10,7 @@ import skimage.io
 
 import slicedimage
 from slicedimage import ImageFormat
+from slicedimage._dimensions import DimensionNames
 from tests.utils import TemporaryDirectory, build_skeleton_manifest
 
 baseurl = "file://{}".format(os.path.abspath(os.path.dirname(__file__)))
@@ -18,17 +19,17 @@ baseurl = "file://{}".format(os.path.abspath(os.path.dirname(__file__)))
 class TestWrite(unittest.TestCase):
     def test_write_tileset(self):
         image = slicedimage.TileSet(
-            ["x", "y", "ch", "hyb"],
+            [DimensionNames.X, DimensionNames.Y, "ch", "hyb"],
             {'ch': 2, 'hyb': 2},
-            {'y': 120, 'x': 80},
+            {DimensionNames.Y: 120, DimensionNames.X: 80},
         )
 
         for hyb in range(2):
             for ch in range(2):
                 tile = slicedimage.Tile(
                     {
-                        'x': (0.0, 0.01),
-                        'y': (0.0, 0.01),
+                        DimensionNames.X: (0.0, 0.01),
+                        DimensionNames.Y: (0.0, 0.01),
                     },
                     {
                         'hyb': hyb,
@@ -69,17 +70,17 @@ class TestWrite(unittest.TestCase):
 
     def test_write_collection(self):
         image = slicedimage.TileSet(
-            ["x", "y", "ch", "hyb"],
+            [DimensionNames.X, DimensionNames.Y, "ch", "hyb"],
             {'ch': 2, 'hyb': 2},
-            {'y': 120, 'x': 80},
+            {DimensionNames.Y: 120, DimensionNames.X: 80},
         )
 
         for hyb in range(2):
             for ch in range(2):
                 tile = slicedimage.Tile(
                     {
-                        'x': (0.0, 0.01),
-                        'y': (0.0, 0.01),
+                        DimensionNames.X: (0.0, 0.01),
+                        DimensionNames.Y: (0.0, 0.01),
                     },
                     {
                         'hyb': hyb,
@@ -138,11 +139,11 @@ class TestWrite(unittest.TestCase):
             manifest['tiles'].append(
                 {
                     "coordinates": {
-                        "x": [
+                        DimensionNames.X.value: [
                             0.0,
                             0.0001,
                         ],
-                        "y": [
+                        DimensionNames.Y.value: [
                             0.0,
                             0.0001,
                         ]
@@ -184,17 +185,17 @@ class TestWrite(unittest.TestCase):
 
     def test_write_tiff(self):
         image = slicedimage.TileSet(
-            dimensions=["x", "y", "ch", "hyb"],
+            dimensions=[DimensionNames.X, DimensionNames.Y, "ch", "hyb"],
             shape={'ch': 2, 'hyb': 2},
-            default_tile_shape={'y': 120, 'x': 80},
+            default_tile_shape={DimensionNames.Y: 120, DimensionNames.X: 80},
         )
 
         for hyb in range(2):
             for ch in range(2):
                 tile = slicedimage.Tile(
                     coordinates={
-                        'x': (0.0, 0.01),
-                        'y': (0.0, 0.01),
+                        DimensionNames.X: (0.0, 0.01),
+                        DimensionNames.Y: (0.0, 0.01),
                     },
                     indices={
                         'hyb': hyb,

--- a/tests/io/v1_0_0/test_missing_shape.py
+++ b/tests/io/v1_0_0/test_missing_shape.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 
 import slicedimage
+from slicedimage._dimensions import DimensionNames
 from slicedimage.io import TileKeys, TileSetKeys
 from tests.utils import TemporaryDirectory
 
@@ -17,7 +18,7 @@ baseurl = "file://{}".format(os.path.abspath(os.path.dirname(__file__)))
 class TestMissingShape(unittest.TestCase):
     def test_tileset_without_shapes(self):
         image = slicedimage.TileSet(
-            ["x", "y", "ch", "hyb"],
+            [DimensionNames.X, DimensionNames.Y, "ch", "hyb"],
             {'ch': 2, 'hyb': 2},
         )
 
@@ -25,8 +26,8 @@ class TestMissingShape(unittest.TestCase):
             for ch in range(2):
                 tile = slicedimage.Tile(
                     {
-                        'x': (0.0, 0.01),
-                        'y': (0.0, 0.01),
+                        DimensionNames.X: (0.0, 0.01),
+                        DimensionNames.Y: (0.0, 0.01),
                     },
                     {
                         'hyb': hyb,
@@ -70,6 +71,6 @@ class TestMissingShape(unittest.TestCase):
 
                         tile_shape = tiles[0].tile_shape
 
-                        self.assertEqual(tile_shape, {'y': 120, 'x': 80})
+                        self.assertEqual(tile_shape, {DimensionNames.Y: 120, DimensionNames.X: 80})
                         self.assertEqual(len(w), 1)
                         self.assertIn("Decoding tile just to obtain shape", str(w[0].message))

--- a/tests/io/v1_0_0/test_reader.py
+++ b/tests/io/v1_0_0/test_reader.py
@@ -7,6 +7,7 @@ import numpy as np
 import skimage.io
 
 import slicedimage
+from slicedimage._dimensions import DimensionNames
 from tests.utils import build_skeleton_manifest, TemporaryDirectory
 
 baseurl = "file://{}".format(os.path.abspath(os.path.dirname(__file__)))
@@ -68,11 +69,11 @@ class TestFormats(unittest.TestCase):
             manifest['tiles'].append(
                 {
                     "coordinates": {
-                        "x": [
+                        DimensionNames.X.value: [
                             0.0,
                             0.0001,
                         ],
-                        "y": [
+                        DimensionNames.Y.value: [
                             0.0,
                             0.0001,
                         ]
@@ -100,15 +101,15 @@ class TestFormats(unittest.TestCase):
         Generate a tileset consisting of a single TIFF tile, and then read it.
         """
         image = slicedimage.TileSet(
-            ["x", "y", "ch", "hyb"],
+            [DimensionNames.X, DimensionNames.Y, "ch", "hyb"],
             {'ch': 1, 'hyb': 1},
-            {'y': 120, 'x': 80},
+            {DimensionNames.Y: 120, DimensionNames.X: 80},
         )
 
         tile = slicedimage.Tile(
             {
-                'x': (0.0, 0.01),
-                'y': (0.0, 0.01),
+                DimensionNames.X: (0.0, 0.01),
+                DimensionNames.Y: (0.0, 0.01),
             },
             {
                 'hyb': 0,

--- a/tests/io/v1_0_0/test_write.py
+++ b/tests/io/v1_0_0/test_write.py
@@ -10,6 +10,7 @@ import skimage.io
 
 import slicedimage
 from slicedimage import ImageFormat
+from slicedimage._dimensions import DimensionNames
 from tests.utils import TemporaryDirectory, build_skeleton_manifest
 
 baseurl = "file://{}".format(os.path.abspath(os.path.dirname(__file__)))
@@ -18,17 +19,17 @@ baseurl = "file://{}".format(os.path.abspath(os.path.dirname(__file__)))
 class TestWrite(unittest.TestCase):
     def test_write_tileset(self):
         image = slicedimage.TileSet(
-            ["x", "y", "ch", "hyb"],
+            [DimensionNames.X, DimensionNames.Y, "ch", "hyb"],
             {'ch': 2, 'hyb': 2},
-            {'y': 120, 'x': 80},
+            {DimensionNames.Y: 120, DimensionNames.X: 80},
         )
 
         for hyb in range(2):
             for ch in range(2):
                 tile = slicedimage.Tile(
                     {
-                        'x': (0.0, 0.01),
-                        'y': (0.0, 0.01),
+                        DimensionNames.X: (0.0, 0.01),
+                        DimensionNames.Y: (0.0, 0.01),
                     },
                     {
                         'hyb': hyb,
@@ -69,17 +70,17 @@ class TestWrite(unittest.TestCase):
 
     def test_write_collection(self):
         image = slicedimage.TileSet(
-            ["x", "y", "ch", "hyb"],
+            [DimensionNames.X, DimensionNames.Y, "ch", "hyb"],
             {'ch': 2, 'hyb': 2},
-            {'y': 120, 'x': 80},
+            {DimensionNames.Y: 120, DimensionNames.X: 80},
         )
 
         for hyb in range(2):
             for ch in range(2):
                 tile = slicedimage.Tile(
                     {
-                        'x': (0.0, 0.01),
-                        'y': (0.0, 0.01),
+                        DimensionNames.X: (0.0, 0.01),
+                        DimensionNames.Y: (0.0, 0.01),
                     },
                     {
                         'hyb': hyb,
@@ -138,11 +139,11 @@ class TestWrite(unittest.TestCase):
             manifest['tiles'].append(
                 {
                     "coordinates": {
-                        "x": [
+                        DimensionNames.X.value: [
                             0.0,
                             0.0001,
                         ],
-                        "y": [
+                        DimensionNames.Y.value: [
                             0.0,
                             0.0001,
                         ]
@@ -184,17 +185,17 @@ class TestWrite(unittest.TestCase):
 
     def test_write_tiff(self):
         image = slicedimage.TileSet(
-            dimensions=["x", "y", "ch", "hyb"],
+            dimensions=[DimensionNames.X, DimensionNames.Y, "ch", "hyb"],
             shape={'ch': 2, 'hyb': 2},
-            default_tile_shape={'y': 120, 'x': 80},
+            default_tile_shape={DimensionNames.Y: 120, DimensionNames.X: 80},
         )
 
         for hyb in range(2):
             for ch in range(2):
                 tile = slicedimage.Tile(
                     coordinates={
-                        'x': (0.0, 0.01),
-                        'y': (0.0, 0.01),
+                        DimensionNames.X: (0.0, 0.01),
+                        DimensionNames.Y: (0.0, 0.01),
                     },
                     indices={
                         'hyb': hyb,


### PR DESCRIPTION
This is the follow on of https://github.com/spacetx/slicedimage/pull/81#discussion_r264361845