### PR TITLE
Allow partitions to be written to any relative path.

### DIFF
--- a/slicedimage/io.py
+++ b/slicedimage/io.py
@@ -272,8 +272,7 @@ class v0_0_0(object):
                         tile_opener=tile_opener,
                         tile_format=tile_format,
                     )
-                    json_doc[CollectionKeys.CONTENTS][partition_name] = os.path.basename(
-                        partition_path)
+                    json_doc[CollectionKeys.CONTENTS][partition_name] = partition_path
                 return json_doc
             elif isinstance(partition, TileSet):
                 json_doc[TileSetKeys.DIMENSIONS] = tuple(partition.dimensions)
@@ -413,8 +412,7 @@ class v1_0_0(object):
                         tile_opener=tile_opener,
                         tile_format=tile_format,
                     )
-                    json_doc[CollectionKeys.CONTENTS][partition_name] = os.path.basename(
-                        partition_path)
+                    json_doc[CollectionKeys.CONTENTS][partition_name] = partition_path
                 return json_doc
             elif isinstance(partition, TileSet):
                 json_doc[TileSetKeys.DIMENSIONS] = tuple(partition.dimensions)

--- a/tests/io/v1_0_0/test_write.py
+++ b/tests/io/v1_0_0/test_write.py
@@ -236,6 +236,65 @@ class TestWrite(unittest.TestCase):
                     self.assertEqual(tiles[0].numpy_array.all(), expected.all())
                     self.assertIsNotNone(tiles[0].sha256)
 
+    def test_write_collection_partition_path(self):
+        image = slicedimage.TileSet(
+            ["x", "y", "ch", "hyb"],
+            {'ch': 2, 'hyb': 2},
+            {'y': 120, 'x': 80},
+        )
+
+        for hyb in range(2):
+            for ch in range(2):
+                tile = slicedimage.Tile(
+                    {
+                        'x': (0.0, 0.01),
+                        'y': (0.0, 0.01),
+                    },
+                    {
+                        'hyb': hyb,
+                        'ch': ch,
+                    },
+                )
+                tile.numpy_array = np.zeros((120, 80))
+                tile.numpy_array[hyb, ch] = 1
+                image.add_tile(tile)
+        collection = slicedimage.Collection()
+        collection.add_partition("fov002", image)
+
+        def partition_path_generator(parent_toc_path, toc_name):
+            toc_basename = os.path.splitext(os.path.basename(parent_toc_path))[0]
+            path = os.path.join(os.path.dirname(parent_toc_path), toc_name)
+            os.makedirs(path)
+            return os.path.join(path, "{}.json".format(toc_basename))
+
+        with TemporaryDirectory() as tempdir, \
+                tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
+            partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
+                collection, partition_file.name, partition_path_generator=partition_path_generator)
+            writer = codecs.getwriter("utf-8")
+            json.dump(partition_doc, writer(partition_file))
+            partition_file.flush()
+
+            basename = os.path.basename(partition_file.name)
+            baseurl = "file://{}".format(os.path.dirname(partition_file.name))
+
+            loaded = slicedimage.Reader.parse_doc(basename, baseurl)
+
+            for hyb in range(2):
+                for ch in range(2):
+                    tiles = [_tile
+                             for _tile in loaded.tiles(
+                                 lambda tile: (tile.indices['hyb'] == hyb and
+                                               tile.indices['ch'] == ch))]
+
+                    self.assertEqual(len(tiles), 1)
+
+                    expected = np.zeros((100, 100))
+                    expected[hyb, ch] = 1
+
+                    self.assertEqual(tiles[0].numpy_array.all(), expected.all())
+                    self.assertIsNotNone(tiles[0].sha256)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Currently, we only take the basename of the partition path generated by `partition_path_generator`.  We should accept any relative path.  This change removes the constraint that the partition be in the same path as the parent path, and adds a test to ensure that it works.

Partially addresses https://github.com/spacetx/starfish/issues/1116