### PR TITLE
Refactor slicedimage write path to use pathlib.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(
 
 setuptools.setup(
     name="slicedimage",
-    version="2.0.0",
+    version="3.0.0",
     description="Library to access sliced imaging data",
     author="Tony Tung",
     author_email="ttung@chanzuckerberg.com",


### PR DESCRIPTION
Refactor slicedimage write path to use pathlib.

This is a functional no-op.  Bumps the version because the API has been modified.

Depends on #85
