### PR TITLE
Permit writing of images to hierarchical on-disk representations.

### DIFF
--- a/slicedimage/io.py
+++ b/slicedimage/io.py
@@ -281,7 +281,8 @@ class v0_0_0(object):
                         tile_opener=tile_opener,
                         tile_format=tile_format,
                     )
-                    json_doc[CollectionKeys.CONTENTS][partition_name] = partition_path.name
+                    json_doc[CollectionKeys.CONTENTS][partition_name] = str(
+                        partition_path.relative_to(path.parent))
                 return json_doc
             elif isinstance(partition, TileSet):
                 json_doc[TileSetKeys.DIMENSIONS] = tuple(partition.dimensions)
@@ -311,7 +312,8 @@ class v0_0_0(object):
 
                         buffer_fh.seek(0)
                         tile_fh.write(buffer_fh.read())
-                        tiledoc[TileKeys.FILE] = tile_fh.name
+                        tiledoc[TileKeys.FILE] = str(
+                            pathlib.Path(tile_fh.name).relative_to(path.parent))
 
                     if tile.tile_shape is not None:
                         tiledoc[TileKeys.TILE_SHAPE] = \


### PR DESCRIPTION
Rather than writing the basename of a referenced file, calculate the relative path from the current file and record that.  Adds a test to verify that such behavior works.

This is the last piece of slicedimage work necessary for https://github.com/spacetx/starfish/issues/1116

Depends on #86 