### PR TITLE
Fix conversion of file:// URLs to local paths.

### DIFF
--- a/slicedimage/_compat.py
+++ b/slicedimage/_compat.py
@@ -1,0 +1,9 @@
+import os
+import sys
+
+
+def fspath(pathlib_path):
+    if sys.version_info >= (3, 6):
+        return os.fspath(pathlib_path)
+    else:
+        return str(pathlib_path)

--- a/slicedimage/io.py
+++ b/slicedimage/io.py
@@ -16,6 +16,7 @@ from six.moves import urllib
 from .backends import CachingBackend, DiskBackend, HttpBackend, S3Backend, SIZE_LIMIT
 from .urlpath import pathjoin, pathsplit
 from ._collection import Collection
+from ._compat import fspath
 from ._formats import ImageFormat
 from ._tile import Tile
 from ._tileset import TileSet
@@ -40,7 +41,9 @@ def infer_backend(baseurl, backend_config=None):
     parsed = urllib.parse.urlparse(baseurl)
 
     if parsed.scheme == "file":
-        return DiskBackend(parsed.path)
+        posix_path = pathlib.PurePosixPath(parsed.path)
+        local_path = pathlib.Path(*posix_path.parts)
+        return DiskBackend(fspath(local_path))
 
     if parsed.scheme in ("http", "https"):
         backend = HttpBackend(baseurl)


### PR DESCRIPTION
Previously, we just extracted the path component and used that as the base path for the DiskCache backend.  However, on Windows, we need to convert the path separators to forward slashes.  We do this by parsing the URL into a posix path, and then creating a local system path from the path components.

Test plan: would be great if this was tested on Windows....