### PR TITLE
Refactor http backend test as a pytest

### DIFF
--- a/tests/io_/v0_1_0/test_http_backend.py
+++ b/tests/io_/v0_1_0/test_http_backend.py
@@ -4,8 +4,8 @@ import os
 import sys
 import tempfile
 import time
-import unittest
 
+import pytest
 import requests
 from requests import HTTPError
 
@@ -17,12 +17,11 @@ from tests.utils import (
 )
 
 
-class TestHttpBackend(unittest.TestCase):
-    def setUp(self, timeout_seconds=5):
-        self.contexts = []
-        self.tempdir = TemporaryDirectory()
-        self.contexts.append(self.tempdir)
-        self.port = unused_tcp_port()
+@pytest.fixture(scope="module")
+def http_server(timeout_seconds=5):
+    with TemporaryDirectory() as tempdir:
+
+        port = unused_tcp_port()
 
         if sys.version_info[0] == 2:
             module = "SimpleHTTPServer"
@@ -31,91 +30,94 @@ class TestHttpBackend(unittest.TestCase):
         else:
             raise Exception("unknown python version")
 
-        self.contexts.append(ContextualChildProcess(
-            [
-                "python",
-                "-m",
-                module,
-                str(self.port),
-            ],
-            cwd=self.tempdir.name,
-        ).__enter__())
+        with ContextualChildProcess(
+                [
+                    "python",
+                    "-m",
+                    module,
+                    str(port),
+                ],
+                cwd=tempdir,
+        ):
+            end = time.time() + timeout_seconds
 
-        end = time.time() + timeout_seconds
-        while True:
-            try:
-                requests.get("http://0.0.0.0:{port}".format(port=self.port))
-                break
-            except requests.ConnectionError:
-                if time.time() > end:
-                    raise
+            while True:
+                try:
+                    requests.get("http://0.0.0.0:{port}".format(port=port))
+                    break
+                except requests.ConnectionError:
+                    if time.time() > end:
+                        raise
 
-        self.http_backend = HttpBackend("http://0.0.0.0:{port}".format(port=self.port))
-
-    def tearDown(self):
-        for context in self.contexts:
-            context.__exit__(*sys.exc_info())
-
-    def test_checksum_good(self):
-        with self._test_checksum_setup(self.tempdir.name) as setupdata:
-            filename, data, expected_checksum = setupdata
-
-            with self.http_backend.read_contextmanager(filename, expected_checksum) as cm:
-                self.assertEqual(cm.read(), data)
-
-    def test_checksum_bad(self):
-        with self._test_checksum_setup(self.tempdir.name) as setupdata:
-            filename, data, expected_checksum = setupdata
-
-            # make the hash incorrect
-            expected_checksum = "{:x}".format(int(hashlib.sha256().hexdigest(), 16) + 1)
-
-            with self.assertRaises(ChecksumValidationError):
-                with self.http_backend.read_contextmanager(filename, expected_checksum) as cm:
-                    self.assertEqual(cm.read(), data)
-
-    def test_reentrant(self):
-        with self._test_checksum_setup(self.tempdir.name) as setupdata:
-            filename, data, expected_checksum = setupdata
-
-            with self.http_backend.read_contextmanager(filename, expected_checksum) as cm0:
-                data0 = cm0.read(1)
-                with self.http_backend.read_contextmanager(filename, expected_checksum) as cm1:
-                    data1 = cm1.read()
-
-                data0 = data0 + cm0.read()
-
-                self.assertEqual(data, data0)
-                self.assertEqual(data, data1)
-
-    @staticmethod
-    @contextlib.contextmanager
-    def _test_checksum_setup(tempdir):
-        """
-        Write some random data to a temporary file and yield its path, the data, and the checksum of
-        the data.
-        """
-        # write the file
-        data = os.urandom(1024)
-
-        expected_checksum = hashlib.sha256(data).hexdigest()
-
-        with tempfile.NamedTemporaryFile(dir=tempdir) as tfh:
-            tfh.write(data)
-            tfh.flush()
-
-            yield os.path.basename(tfh.name), data, expected_checksum
-
-    def test_error(self):
-        """
-        Verifies that we raise an exception when we fail to find a file.
-        """
-        with self.assertRaises(HTTPError):
-            backend = HttpBackend("http://0.0.0.0:{port}".format(port=self.port))
-            with self.assertRaises(ChecksumValidationError):
-                with backend.read_contextmanager("tileset.json") as cm:
-                    cm.read()
+            yield tempdir, port
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_checksum_good(http_server):
+    tempdir, port = http_server
+    http_backend = HttpBackend("http://0.0.0.0:{port}".format(port=port))
+    with _test_checksum_setup(tempdir) as setupdata:
+        filename, data, expected_checksum = setupdata
+
+        with http_backend.read_contextmanager(filename, expected_checksum) as cm:
+            assert cm.read() == data
+
+
+def test_checksum_bad(http_server):
+    tempdir, port = http_server
+    http_backend = HttpBackend("http://0.0.0.0:{port}".format(port=port))
+    with _test_checksum_setup(tempdir) as setupdata:
+        filename, data, expected_checksum = setupdata
+
+        # make the hash incorrect
+        expected_checksum = "{:x}".format(int(hashlib.sha256().hexdigest(), 16) + 1)
+
+        with pytest.raises(ChecksumValidationError):
+            with http_backend.read_contextmanager(filename, expected_checksum) as cm:
+                assert cm.read() == data
+
+
+def test_reentrant(http_server):
+    tempdir, port = http_server
+    http_backend = HttpBackend("http://0.0.0.0:{port}".format(port=port))
+    with _test_checksum_setup(tempdir) as setupdata:
+        filename, data, expected_checksum = setupdata
+
+        with http_backend.read_contextmanager(filename, expected_checksum) as cm0:
+            data0 = cm0.read(1)
+            with http_backend.read_contextmanager(filename, expected_checksum) as cm1:
+                data1 = cm1.read()
+
+            data0 = data0 + cm0.read()
+
+            assert data == data0
+            assert data == data1
+
+
+@contextlib.contextmanager
+def _test_checksum_setup(tempdir):
+    """
+    Write some random data to a temporary file and yield its path, the data, and the checksum of
+    the data.
+    """
+    # write the file
+    data = os.urandom(1024)
+
+    expected_checksum = hashlib.sha256(data).hexdigest()
+
+    with tempfile.NamedTemporaryFile(dir=tempdir) as tfh:
+        tfh.write(data)
+        tfh.flush()
+
+        yield os.path.basename(tfh.name), data, expected_checksum
+
+
+def test_error(http_server):
+    """
+    Verifies that we raise an exception when we fail to find a file.
+    """
+    tempdir, port = http_server
+    http_backend = HttpBackend("http://0.0.0.0:{port}".format(port=port))
+    with pytest.raises(HTTPError):
+        with pytest.raises(ChecksumValidationError):
+            with http_backend.read_contextmanager("tileset.json") as cm:
+                cm.read()


### PR DESCRIPTION
This is facilitate the testing of a retriable HTTP request.  We need to monkeypatch the status codes that trigger a HTTP retry.

1. Remove the unittest class construct.
2. Make the http server a fixture.