### PR TITLE
Delay S3 resource construction until object requested

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(
 
 setuptools.setup(
     name="slicedimage",
-    version="4.0.0",
+    version="4.0.1",
     description="Library to access sliced imaging data",
     author="Tony Tung",
     author_email="ttung@chanzuckerberg.com",

--- a/slicedimage/io/_base.py
+++ b/slicedimage/io/_base.py
@@ -329,6 +329,7 @@ def _parse_collection(parse_method, baseurl, backend_config):
     """
     def parse(name_relative_path_or_url_tuple):
         name, relative_path_or_url = name_relative_path_or_url_tuple
+
         partition = parse_method(relative_path_or_url, baseurl, backend_config)
         partition._name_or_url = relative_path_or_url
 


### PR DESCRIPTION
Constructing a S3 handle takes up memory and time.  We retrieve the backend whenever we initialize a tile, but we want to delay the expensive work until the data is requested.

The perf issue is sufficiently bad that we want to do a release, so bumping to 4.0.1.

Test plan: Able to quickly load an experiment where all the tiles are located in th ecloud.