### PR TITLE
Fix Windows path resolution

### DIFF
--- a/slicedimage/url/resolve.py
+++ b/slicedimage/url/resolve.py
@@ -26,8 +26,12 @@ def infer_backend(baseurl, backend_config=None):
     parsed = urllib.parse.urlparse(baseurl)
 
     if parsed.scheme == "file":
-        posix_path = pathlib.PurePosixPath(parsed.path)
-        local_path = pathlib.Path(*posix_path.parts)
+        if os.name == "nt":
+            # pathlib can parse c:/windows/xxx, but not /c:/windows/xxx.  however, url paths always
+            # start with a /
+            local_path = pathlib.Path(parsed.path[1:])
+        else:
+            local_path = pathlib.Path(parsed.path)
         return DiskBackend(fspath(local_path))
 
     if parsed.scheme in ("http", "https"):


### PR DESCRIPTION
When extracting the path component from urllib.parse.urlparse, the path always starts with '/'.  When tokenizing the url into its components, it becomes '/', 'c:', 'windows', 'system32'.  Unfortunately, when combined into a WindowsPath, it becomes 'c:windows/system32', which honestly makes no sense to me.

The approach here is to strip the prefix '/', and when we do that, WindowsPath can parse the posix path correctly.

Thanks to @dany-fu for reporting this.

Test plan: loaded up a very empty experiment.json on a Windows VM.