### PR TITLE
Fix handling of paths with spaces.

### DIFF
--- a/slicedimage/url/path.py
+++ b/slicedimage/url/path.py
@@ -25,7 +25,7 @@ def _parse_absolute_url(absolute_url) -> Tuple[str, str]:
         raise ValueError("Not an absolute url.")
 
     return (
-        posixpath.basename(parsed.path),
+        posixpath.basename(urllib.parse.unquote(parsed.path)),
         urllib.parse.urlunparse(
             (parsed.scheme,
              parsed.netloc,

--- a/slicedimage/url/resolve.py
+++ b/slicedimage/url/resolve.py
@@ -29,9 +29,9 @@ def infer_backend(baseurl, backend_config=None):
         if os.name == "nt":
             # pathlib can parse c:/windows/xxx, but not /c:/windows/xxx.  however, url paths always
             # start with a /
-            local_path = pathlib.Path(parsed.path[1:])
+            local_path = pathlib.Path(urllib.parse.unquote(parsed.path[1:]))
         else:
-            local_path = pathlib.Path(parsed.path)
+            local_path = pathlib.Path(urllib.parse.unquote(parsed.path))
         return DiskBackend(fspath(local_path))
 
     if parsed.scheme in ("http", "https"):

--- a/tests/io_/test_resolve_url.py
+++ b/tests/io_/test_resolve_url.py
@@ -2,7 +2,10 @@ import os
 import tempfile
 import unittest
 import uuid
+from pathlib import Path
 
+from slicedimage._compat import fspath
+from slicedimage.backends import DiskBackend
 from slicedimage.url.resolve import resolve_path_or_url, resolve_url
 
 
@@ -22,6 +25,33 @@ class TestResolvePathOrUrl(unittest.TestCase):
                 self.assertEqual("file://{}".format(os.path.dirname(abspath)), baseurl)
             finally:
                 os.chdir(cwd)
+
+    def test_local_path_with_spaces(self):
+        with tempfile.TemporaryDirectory(prefix="c d") as td:
+            with tempfile.NamedTemporaryFile(dir=td, prefix="a b") as tfn:
+                abspath = Path(tfn.name).resolve()
+                backend, name, baseurl = resolve_path_or_url(fspath(abspath))
+                self.assertEqual(name, abspath.name)
+                self.assertTrue(isinstance(backend, DiskBackend))
+                self.assertEqual(fspath(abspath.parent), backend._basedir)
+                self.assertEqual(abspath.parent.as_uri(), baseurl)
+
+                with backend.read_contextmanager(name) as rcm:
+                    rcm.read()
+
+                cwd = os.getcwd()
+                try:
+                    os.chdir(fspath(abspath.parent))
+                    backend, name, baseurl = resolve_path_or_url(abspath.name)
+                    self.assertEqual(name, abspath.name)
+                    self.assertTrue(isinstance(backend, DiskBackend))
+                    self.assertEqual(fspath(abspath.parent), backend._basedir)
+                    self.assertEqual(abspath.parent.as_uri(), baseurl)
+
+                    with backend.read_contextmanager(name) as rcm:
+                        rcm.read()
+                finally:
+                    os.chdir(cwd)
 
     def test_invalid_local_path(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
When we convert from url path to local path, we should decode the %-encoded characters.

Test plan: Added a test that creates local paths with spaces.  Ensure they are processed correctly.

Fixes https://github.com/spacetx/starfish/issues/1492