### PR TITLE
[easy] Change 0.0.0.0 to 127.0.0.1

### DIFF
--- a/tests/io_/v0_0_0/test_caching_backend.py
+++ b/tests/io_/v0_0_0/test_caching_backend.py
@@ -42,7 +42,7 @@ class TestCachingBackend(unittest.TestCase):
         end = time.time() + timeout_seconds
         while True:
             try:
-                requests.get("http://0.0.0.0:{port}".format(port=self.port))
+                requests.get("http://127.0.0.1:{port}".format(port=self.port))
                 break
             except requests.ConnectionError:
                 if time.time() > end:
@@ -51,7 +51,7 @@ class TestCachingBackend(unittest.TestCase):
         self.cachedir = tempfile.TemporaryDirectory()
         self.contexts.append(self.cachedir)
 
-        self.http_backend = HttpBackend("http://0.0.0.0:{port}".format(port=self.port))
+        self.http_backend = HttpBackend("http://127.0.0.1:{port}".format(port=self.port))
         self.caching_backend = CachingBackend(self.cachedir.name, self.http_backend)
 
     def tearDown(self):

--- a/tests/io_/v0_0_0/test_http_backend.py
+++ b/tests/io_/v0_0_0/test_http_backend.py
@@ -43,13 +43,13 @@ class TestHttpBackend(unittest.TestCase):
         end = time.time() + timeout_seconds
         while True:
             try:
-                requests.get("http://0.0.0.0:{port}".format(port=self.port))
+                requests.get("http://127.0.0.1:{port}".format(port=self.port))
                 break
             except requests.ConnectionError:
                 if time.time() > end:
                     raise
 
-        self.http_backend = HttpBackend("http://0.0.0.0:{port}".format(port=self.port))
+        self.http_backend = HttpBackend("http://127.0.0.1:{port}".format(port=self.port))
 
     def tearDown(self):
         for context in reversed(self.contexts):
@@ -110,7 +110,7 @@ class TestHttpBackend(unittest.TestCase):
         Verifies that we raise an exception when we fail to find a file.
         """
         with self.assertRaises(HTTPError):
-            backend = HttpBackend("http://0.0.0.0:{port}".format(port=self.port))
+            backend = HttpBackend("http://127.0.0.1:{port}".format(port=self.port))
             with self.assertRaises(ChecksumValidationError):
                 with backend.read_contextmanager("tileset.json") as cm:
                     cm.read()

--- a/tests/io_/v0_1_0/test_caching_backend.py
+++ b/tests/io_/v0_1_0/test_caching_backend.py
@@ -43,7 +43,7 @@ class TestCachingBackend(unittest.TestCase):
         end = time.time() + timeout_seconds
         while True:
             try:
-                requests.get("http://0.0.0.0:{port}".format(port=self.port))
+                requests.get("http://127.0.0.1:{port}".format(port=self.port))
                 break
             except requests.ConnectionError:
                 if time.time() > end:
@@ -52,7 +52,7 @@ class TestCachingBackend(unittest.TestCase):
         self.cachedir = tempfile.TemporaryDirectory()
         self.contexts.append(self.cachedir)
 
-        self.http_backend = HttpBackend("http://0.0.0.0:{port}".format(port=self.port))
+        self.http_backend = HttpBackend("http://127.0.0.1:{port}".format(port=self.port))
         self.caching_backend = CachingBackend(self.cachedir.name, self.http_backend)
 
     def tearDown(self):

--- a/tests/io_/v0_1_0/test_http_backend.py
+++ b/tests/io_/v0_1_0/test_http_backend.py
@@ -44,7 +44,7 @@ def http_server(timeout_seconds=5):
 
             while True:
                 try:
-                    requests.get("http://0.0.0.0:{port}".format(port=port))
+                    requests.get("http://127.0.0.1:{port}".format(port=port))
                     break
                 except requests.ConnectionError:
                     if time.time() > end:
@@ -55,7 +55,7 @@ def http_server(timeout_seconds=5):
 
 def test_checksum_good(http_server):
     tempdir, port = http_server
-    http_backend = HttpBackend("http://0.0.0.0:{port}".format(port=port))
+    http_backend = HttpBackend("http://127.0.0.1:{port}".format(port=port))
     with _test_checksum_setup(tempdir) as setupdata:
         filename, data, expected_checksum = setupdata
 
@@ -65,7 +65,7 @@ def test_checksum_good(http_server):
 
 def test_checksum_bad(http_server):
     tempdir, port = http_server
-    http_backend = HttpBackend("http://0.0.0.0:{port}".format(port=port))
+    http_backend = HttpBackend("http://127.0.0.1:{port}".format(port=port))
     with _test_checksum_setup(tempdir) as setupdata:
         filename, data, expected_checksum = setupdata
 
@@ -79,7 +79,7 @@ def test_checksum_bad(http_server):
 
 def test_reentrant(http_server):
     tempdir, port = http_server
-    http_backend = HttpBackend("http://0.0.0.0:{port}".format(port=port))
+    http_backend = HttpBackend("http://127.0.0.1:{port}".format(port=port))
     with _test_checksum_setup(tempdir) as setupdata:
         filename, data, expected_checksum = setupdata
 
@@ -117,7 +117,7 @@ def test_error(http_server):
     Verifies that we raise an exception when we fail to find a file.
     """
     tempdir, port = http_server
-    http_backend = HttpBackend("http://0.0.0.0:{port}".format(port=port))
+    http_backend = HttpBackend("http://127.0.0.1:{port}".format(port=port))
     with pytest.raises(HTTPError):
         with pytest.raises(ChecksumValidationError):
             with http_backend.read_contextmanager("tileset.json") as cm:
@@ -134,7 +134,7 @@ def test_retry(monkeypatch, http_server):
     file.
     """
     tempdir, port = http_server
-    http_backend = HttpBackend("http://0.0.0.0:{port}".format(port=port))
+    http_backend = HttpBackend("http://127.0.0.1:{port}".format(port=port))
 
     def sleep_and_make_file():
         time.sleep(5.0)


### PR DESCRIPTION
Windows does not like binding to 0.0.0.0 (all interfaces on POSIX systems).  Bind to 127.0.0.1, which works.

Test plan: pass on Windows.
Part of https://github.com/spacetx/starfish/issues/1296