### PR TITLE
Simplify HTTP connection code

### DIFF
--- a/tests/io_/v0_0_0/test_caching_backend.py
+++ b/tests/io_/v0_0_0/test_caching_backend.py
@@ -23,19 +23,14 @@ class TestCachingBackend(unittest.TestCase):
         self.contexts.append(self.tempdir)
         self.port = unused_tcp_port()
 
-        if sys.version_info[0] == 2:
-            module = "SimpleHTTPServer"
-        elif sys.version_info[0] == 3:
-            module = "http.server"
-        else:
-            raise Exception("unknown python version")
-
         self.contexts.append(ContextualChildProcess(
             [
                 "python",
                 "-m",
-                module,
+                "http.server",
                 str(self.port),
+                "--bind",
+                "127.0.0.1",
             ],
             cwd=self.tempdir.name,
         ).__enter__())

--- a/tests/io_/v0_0_0/test_http_backend.py
+++ b/tests/io_/v0_0_0/test_http_backend.py
@@ -23,19 +23,14 @@ class TestHttpBackend(unittest.TestCase):
         self.contexts.append(self.tempdir)
         self.port = unused_tcp_port()
 
-        if sys.version_info[0] == 2:
-            module = "SimpleHTTPServer"
-        elif sys.version_info[0] == 3:
-            module = "http.server"
-        else:
-            raise Exception("unknown python version")
-
         self.contexts.append(ContextualChildProcess(
             [
                 "python",
                 "-m",
-                module,
+                "http.server",
                 str(self.port),
+                "--bind",
+                "127.0.0.1",
             ],
             cwd=self.tempdir.name,
         ).__enter__())

--- a/tests/io_/v0_1_0/test_caching_backend.py
+++ b/tests/io_/v0_1_0/test_caching_backend.py
@@ -24,19 +24,14 @@ class TestCachingBackend(unittest.TestCase):
         self.contexts.append(self.tempdir)
         self.port = unused_tcp_port()
 
-        if sys.version_info[0] == 2:
-            module = "SimpleHTTPServer"
-        elif sys.version_info[0] == 3:
-            module = "http.server"
-        else:
-            raise Exception("unknown python version")
-
         self.contexts.append(ContextualChildProcess(
             [
                 "python",
                 "-m",
-                module,
+                "http.server",
                 str(self.port),
+                "--bind",
+                "127.0.0.1",
             ],
             cwd=self.tempdir.name,
         ).__enter__())

--- a/tests/io_/v0_1_0/test_http_backend.py
+++ b/tests/io_/v0_1_0/test_http_backend.py
@@ -1,7 +1,6 @@
 import contextlib
 import hashlib
 import os
-import sys
 import tempfile
 import threading
 import time
@@ -24,19 +23,14 @@ def http_server(timeout_seconds=5):
 
         port = unused_tcp_port()
 
-        if sys.version_info[0] == 2:
-            module = "SimpleHTTPServer"
-        elif sys.version_info[0] == 3:
-            module = "http.server"
-        else:
-            raise Exception("unknown python version")
-
         with ContextualChildProcess(
                 [
                     "python",
                     "-m",
-                    module,
+                    "http.server",
                     str(port),
+                    "--bind",
+                    "127.0.0.1",
                 ],
                 cwd=tempdir,
         ):


### PR DESCRIPTION
We removed python 2.x support in #102, so this code should and can be simplified.

Test plan: `make -j test`