### PR TITLE
Eliminate string construction of file:// urls.

### DIFF
--- a/tests/io_/test_resolve_url.py
+++ b/tests/io_/test_resolve_url.py
@@ -12,17 +12,17 @@ from slicedimage.url.resolve import resolve_path_or_url, resolve_url
 class TestResolvePathOrUrl(unittest.TestCase):
     def test_valid_local_path(self):
         with tempfile.NamedTemporaryFile() as tfn:
-            abspath = os.path.realpath(tfn.name)
-            _, name, baseurl = resolve_path_or_url(abspath)
-            self.assertEqual(name, os.path.basename(abspath))
-            self.assertEqual("file://{}".format(os.path.dirname(abspath)), baseurl)
+            abspath = Path(tfn.name).resolve()
+            _, name, baseurl = resolve_path_or_url(fspath(abspath))
+            self.assertEqual(name, abspath.name)
+            self.assertEqual(abspath.parent.as_uri(), baseurl)
 
             cwd = os.getcwd()
             try:
-                os.chdir(os.path.dirname(abspath))
-                _, name, baseurl = resolve_path_or_url(os.path.basename(abspath))
-                self.assertEqual(name, os.path.basename(abspath))
-                self.assertEqual("file://{}".format(os.path.dirname(abspath)), baseurl)
+                os.chdir(fspath(abspath.parent))
+                _, name, baseurl = resolve_path_or_url(abspath.name)
+                self.assertEqual(name, abspath.name)
+                self.assertEqual(abspath.parent.as_uri(), baseurl)
             finally:
                 os.chdir(cwd)
 

--- a/tests/io_/v0_1_0/test_http_backend.py
+++ b/tests/io_/v0_1_0/test_http_backend.py
@@ -19,7 +19,7 @@ from tests.utils import (
 
 @pytest.fixture(scope="module")
 def http_server(timeout_seconds=5):
-    with tempfile.  TemporaryDirectory() as tempdir:
+    with tempfile.TemporaryDirectory() as tempdir:
 
         port = unused_tcp_port()
 

--- a/tests/io_/v0_1_0/test_missing_shape.py
+++ b/tests/io_/v0_1_0/test_missing_shape.py
@@ -1,9 +1,9 @@
 import codecs
 import json
-import os
 import tempfile
 import unittest
 import warnings
+from pathlib import Path
 
 import numpy as np
 
@@ -11,7 +11,7 @@ import slicedimage
 from slicedimage._dimensions import DimensionNames
 from slicedimage.io._keys import TileKeys, TileSetKeys
 
-baseurl = "file://{}".format(os.path.abspath(os.path.dirname(__file__)))
+baseurl = Path(__file__).parent.resolve().as_uri()
 
 
 class TestMissingShape(unittest.TestCase):
@@ -39,8 +39,9 @@ class TestMissingShape(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tempdir, \
                 tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
-            partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                image, "file://{}".format(partition_file.name))
+            partition_file_path = Path(partition_file.name)
+            partition_doc = slicedimage.v0_1_0.Writer().generate_partition_document(
+                image, partition_file_path.as_uri())
 
             # remove the shape information from the tiles.
             for tile in partition_doc[TileSetKeys.TILES]:
@@ -50,10 +51,8 @@ class TestMissingShape(unittest.TestCase):
             json.dump(partition_doc, writer(partition_file))
             partition_file.flush()
 
-            basename = os.path.basename(partition_file.name)
-            baseurl = "file://{}".format(os.path.dirname(partition_file.name))
-
-            loaded = slicedimage.Reader.parse_doc(basename, baseurl)
+            loaded = slicedimage.Reader.parse_doc(
+                partition_file_path.name, partition_file_path.parent.as_uri())
 
             for hyb in range(2):
                 for ch in range(2):

--- a/tests/io_/v0_1_0/test_reader.py
+++ b/tests/io_/v0_1_0/test_reader.py
@@ -3,15 +3,17 @@ import json
 import os
 import tempfile
 import unittest
+from pathlib import Path
 
 import tifffile
 import numpy as np
+from slicedimage._compat import fspath
 
 import slicedimage
 from slicedimage._dimensions import DimensionNames
 from tests.utils import build_skeleton_manifest
 
-baseurl = "file://{}".format(os.path.abspath(os.path.dirname(__file__)))
+baseurl = Path(__file__).parent.resolve().as_uri()
 
 
 class TestReader(unittest.TestCase):
@@ -60,6 +62,7 @@ class TestFormats(unittest.TestCase):
         Generate a tileset consisting of a single TIFF tile, and then read it.
         """
         with tempfile.TemporaryDirectory() as tempdir:
+            tempdir_path = Path(tempdir)
             # write the tiff file
             data = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
             with tifffile.TiffWriter(os.path.join(tempdir, "tile.tiff")) as tiff:
@@ -88,13 +91,10 @@ class TestFormats(unittest.TestCase):
                     "format": "tiff",
                 },
             )
-            with open(os.path.join(tempdir, "tileset.json"), "w") as fh:
+            with open(fspath(tempdir_path / "tileset.json"), "w") as fh:
                 fh.write(json.dumps(manifest))
 
-            result = slicedimage.Reader.parse_doc(
-                "tileset.json",
-                "file://{}".format(tempdir),
-            )
+            result = slicedimage.Reader.parse_doc("tileset.json", tempdir_path.as_uri())
 
             self.assertTrue(np.array_equal(list(result.tiles())[0].numpy_array, data))
 
@@ -122,16 +122,14 @@ class TestFormats(unittest.TestCase):
         image.add_tile(tile)
 
         with tempfile.TemporaryDirectory() as tempdir:
-            partition_path = os.path.join(tempdir, "tileset.json")
+            tempdir_path = Path(tempdir)
+            partition_file_path = tempdir_path / "tileset.json"
             partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                image, "file://{}".format(partition_path))
-            with open(partition_path, "w") as fh:
+                image, partition_file_path.as_uri())
+            with open(fspath(partition_file_path), "w") as fh:
                 json.dump(partition_doc, fh)
 
-            result = slicedimage.Reader.parse_doc(
-                "tileset.json",
-                "file://{}".format(tempdir),
-            )
+            result = slicedimage.Reader.parse_doc("tileset.json", tempdir_path.as_uri())
 
             self.assertTrue(np.array_equal(list(result.tiles())[0].numpy_array, tile.numpy_array))
 

--- a/tests/io_/v0_1_0/test_write.py
+++ b/tests/io_/v0_1_0/test_write.py
@@ -4,16 +4,18 @@ import json
 import os
 import tempfile
 import unittest
+from pathlib import Path
 
 import tifffile
 import numpy as np
+from slicedimage._compat import fspath
 
 import slicedimage
 from slicedimage import ImageFormat
 from slicedimage._dimensions import DimensionNames
 from tests.utils import build_skeleton_manifest
 
-baseurl = "file://{}".format(os.path.abspath(os.path.dirname(__file__)))
+baseurl = Path(__file__).parent.resolve().as_uri()
 
 
 class TestWrite(unittest.TestCase):
@@ -42,16 +44,15 @@ class TestWrite(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tempdir, \
                 tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
+            partition_file_path = Path(partition_file.name)
             partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                image, "file://{}".format(partition_file.name))
+                image, partition_file_path.as_uri())
             writer = codecs.getwriter("utf-8")
             json.dump(partition_doc, writer(partition_file))
             partition_file.flush()
 
-            basename = os.path.basename(partition_file.name)
-            baseurl = "file://{}".format(os.path.dirname(partition_file.name))
-
-            loaded = slicedimage.Reader.parse_doc(basename, baseurl)
+            loaded = slicedimage.Reader.parse_doc(
+                partition_file_path.name, partition_file_path.parent.as_uri())
 
             for hyb in range(2):
                 for ch in range(2):
@@ -96,16 +97,15 @@ class TestWrite(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tempdir, \
                 tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
+            partition_file_path = Path(partition_file.name)
             partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                collection, "file://{}".format(partition_file.name))
+                collection, partition_file_path.as_uri())
             writer = codecs.getwriter("utf-8")
             json.dump(partition_doc, writer(partition_file))
             partition_file.flush()
 
-            basename = os.path.basename(partition_file.name)
-            baseurl = "file://{}".format(os.path.dirname(partition_file.name))
-
-            loaded = slicedimage.Reader.parse_doc(basename, baseurl)
+            loaded = slicedimage.Reader.parse_doc(
+                partition_file_path.name, partition_file_path.parent.as_uri())
 
             for hyb in range(2):
                 for ch in range(2):
@@ -131,6 +131,7 @@ class TestWrite(unittest.TestCase):
         """
         # write the tiff file
         with tempfile.TemporaryDirectory() as tempdir:
+            tempdir_path = Path(tempdir)
             data = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
             file_path = os.path.join(tempdir, "tile.tiff")
             with tifffile.TiffWriter(file_path) as tiff:
@@ -160,29 +161,28 @@ class TestWrite(unittest.TestCase):
                     "sha256": checksum,
                 },
             )
-            with open(os.path.join(tempdir, "tileset.json"), "w") as fh:
+            with open(fspath(tempdir_path / "tileset.json"), "w") as fh:
                 fh.write(json.dumps(manifest))
 
             image = slicedimage.Reader.parse_doc(
                 "tileset.json",
-                "file://{}".format(tempdir),
+                tempdir_path.as_uri(),
                 {"cache": {"size_limit": 0}},  # disabled
             )
 
             with tempfile.TemporaryDirectory() as output_tempdir, \
                     tempfile.NamedTemporaryFile(
                         suffix=".json", dir=output_tempdir) as partition_file:
+                partition_file_path = Path(partition_file.name)
                 partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                    image, "file://{}".format(partition_file.name))
+                    image, partition_file_path.as_uri())
 
                 writer = codecs.getwriter("utf-8")
                 json.dump(partition_doc, writer(partition_file))
                 partition_file.flush()
 
-                basename = os.path.basename(partition_file.name)
-                baseurl = "file://{}".format(os.path.dirname(partition_file.name))
-
-                loaded = slicedimage.Reader.parse_doc(basename, baseurl)
+                loaded = slicedimage.Reader.parse_doc(
+                    partition_file_path.name, partition_file_path.parent.as_uri())
 
                 loaded.tiles()[0].numpy_array
 
@@ -211,17 +211,17 @@ class TestWrite(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tempdir, \
                 tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
+            partition_file_path = Path(partition_file.name)
             # create the tileset and save it.
             partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                image, "file://{}".format(partition_file.name), tile_format=ImageFormat.TIFF)
+                image, partition_file_path.as_uri(), tile_format=ImageFormat.TIFF)
             writer = codecs.getwriter("utf-8")
             json.dump(partition_doc, writer(partition_file))
             partition_file.flush()
 
             # construct a URL to the tileset we wrote, and load the tileset.
-            basename = os.path.basename(partition_file.name)
-            baseurl = "file://{}".format(os.path.dirname(partition_file.name))
-            loaded = slicedimage.Reader.parse_doc(basename, baseurl)
+            loaded = slicedimage.Reader.parse_doc(
+                partition_file_path.name, partition_file_path.parent.as_uri())
 
             # compare the tiles we loaded to the tiles we set up.
             for hyb in range(2):
@@ -282,8 +282,9 @@ class TestWrite(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tempdir, \
                 tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
+            partition_file_path = Path(partition_file.name)
             partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                collection, "file://{}".format(partition_file.name),
+                collection, partition_file_path.as_uri(),
                 partition_path_generator=partition_path_generator,
                 tile_opener=tile_opener,
             )
@@ -291,10 +292,8 @@ class TestWrite(unittest.TestCase):
             json.dump(partition_doc, writer(partition_file))
             partition_file.flush()
 
-            basename = os.path.basename(partition_file.name)
-            baseurl = "file://{}".format(os.path.dirname(partition_file.name))
-
-            loaded = slicedimage.Reader.parse_doc(basename, baseurl)
+            loaded = slicedimage.Reader.parse_doc(
+                partition_file_path.name, partition_file_path.parent.as_uri())
 
             for hyb in range(2):
                 for ch in range(2):


### PR DESCRIPTION
Use Pathlib's `as_uri()` method, which is cross-platform.

Test plan: `make test`
Part of https://github.com/spacetx/starfish/issues/1296