### PR TITLE
Close files before using them in tests

### DIFF
--- a/tests/io_/test_resolve_url.py
+++ b/tests/io_/test_resolve_url.py
@@ -28,9 +28,22 @@ class TestResolvePathOrUrl(unittest.TestCase):
 
     def test_local_path_with_spaces(self):
         with tempfile.TemporaryDirectory(prefix="c d") as td:
-            with tempfile.NamedTemporaryFile(dir=td, prefix="a b") as tfn:
-                abspath = Path(tfn.name).resolve()
-                backend, name, baseurl = resolve_path_or_url(fspath(abspath))
+            with tempfile.NamedTemporaryFile(dir=td, prefix="a b", delete=False) as tfn:
+                pass
+            abspath = Path(tfn.name).resolve()
+            backend, name, baseurl = resolve_path_or_url(fspath(abspath))
+            self.assertEqual(name, abspath.name)
+            self.assertTrue(isinstance(backend, DiskBackend))
+            self.assertEqual(fspath(abspath.parent), backend._basedir)
+            self.assertEqual(abspath.parent.as_uri(), baseurl)
+
+            with backend.read_contextmanager(name) as rcm:
+                rcm.read()
+
+            cwd = os.getcwd()
+            try:
+                os.chdir(fspath(abspath.parent))
+                backend, name, baseurl = resolve_path_or_url(abspath.name)
                 self.assertEqual(name, abspath.name)
                 self.assertTrue(isinstance(backend, DiskBackend))
                 self.assertEqual(fspath(abspath.parent), backend._basedir)
@@ -38,20 +51,8 @@ class TestResolvePathOrUrl(unittest.TestCase):
 
                 with backend.read_contextmanager(name) as rcm:
                     rcm.read()
-
-                cwd = os.getcwd()
-                try:
-                    os.chdir(fspath(abspath.parent))
-                    backend, name, baseurl = resolve_path_or_url(abspath.name)
-                    self.assertEqual(name, abspath.name)
-                    self.assertTrue(isinstance(backend, DiskBackend))
-                    self.assertEqual(fspath(abspath.parent), backend._basedir)
-                    self.assertEqual(abspath.parent.as_uri(), baseurl)
-
-                    with backend.read_contextmanager(name) as rcm:
-                        rcm.read()
-                finally:
-                    os.chdir(cwd)
+            finally:
+                os.chdir(cwd)
 
     def test_invalid_local_path(self):
         with self.assertRaises(ValueError):

--- a/tests/io_/v0_0_0/test_caching_backend.py
+++ b/tests/io_/v0_0_0/test_caching_backend.py
@@ -133,11 +133,10 @@ class TestCachingBackend(unittest.TestCase):
 
         expected_checksum = hashlib.sha256(data).hexdigest()
 
-        with tempfile.NamedTemporaryFile(dir=tempdir) as tfh:
+        with tempfile.NamedTemporaryFile(dir=tempdir, delete=False) as tfh:
             tfh.write(data)
-            tfh.flush()
 
-            yield os.path.basename(tfh.name), data, expected_checksum
+        yield os.path.basename(tfh.name), data, expected_checksum
 
 
 if __name__ == "__main__":

--- a/tests/io_/v0_0_0/test_disk_backend.py
+++ b/tests/io_/v0_0_0/test_disk_backend.py
@@ -2,69 +2,68 @@ import contextlib
 import hashlib
 import os
 import tempfile
-import unittest
+from pathlib import Path
 
+import pytest
+
+from slicedimage._compat import fspath
 from slicedimage.backends import ChecksumValidationError, DiskBackend
 
 
-class TestDiskBackend(unittest.TestCase):
-    def test_checksum_good(self):
-        with self._test_checksum_setup() as setupdata:
-            filepath, data, expected_checksum = setupdata
+def test_checksum_good(tmpdir):
+    with _test_checksum_setup(tmpdir) as setupdata:
+        filepath, data, expected_checksum = setupdata
 
-            backend = DiskBackend(os.path.dirname(filepath))
-            with backend.read_contextmanager(os.path.basename(filepath), expected_checksum) as cm:
-                self.assertEqual(cm.read(), data)
-
-    def test_checksum_bad(self):
-        with self._test_checksum_setup() as setupdata:
-            filepath, data, expected_checksum = setupdata
-
-            # make the hash incorrect
-            expected_checksum = "{:x}".format(int(hashlib.sha256().hexdigest(), 16) + 1)
-
-            backend = DiskBackend(os.path.dirname(filepath))
-            with self.assertRaises(ChecksumValidationError):
-                with backend.read_contextmanager(
-                        os.path.basename(filepath),
-                        expected_checksum) as cm:
-                    self.assertEqual(cm.read(), data)
-
-    def test_reentrant(self):
-        with self._test_checksum_setup() as setupdata:
-            filepath, data, expected_checksum = setupdata
-
-            backend = DiskBackend(os.path.dirname(filepath))
-            with backend.read_contextmanager(os.path.basename(filepath), expected_checksum) as cm0:
-                data0 = cm0.read(1)
-                with backend.read_contextmanager(
-                        os.path.basename(filepath),
-                        expected_checksum) as cm1:
-                    data1 = cm1.read()
-
-                data0 = data0 + cm0.read()
-
-                self.assertEqual(data, data0)
-                self.assertEqual(data, data1)
-
-    @staticmethod
-    @contextlib.contextmanager
-    def _test_checksum_setup():
-        """
-        Write some random data to a temporary file and yield its path, the data, and the checksum of
-        the data.
-        """
-        # write the file
-        data = os.urandom(1024)
-
-        expected_checksum = hashlib.sha256(data).hexdigest()
-
-        with tempfile.NamedTemporaryFile() as tfh:
-            tfh.write(data)
-            tfh.flush()
-
-            yield tfh.name, data, expected_checksum
+        backend = DiskBackend(os.path.dirname(filepath))
+        with backend.read_contextmanager(os.path.basename(filepath), expected_checksum) as cm:
+            assert cm.read() == data
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_checksum_bad(tmpdir):
+    with _test_checksum_setup(tmpdir) as setupdata:
+        filepath, data, expected_checksum = setupdata
+
+        # make the hash incorrect
+        expected_checksum = "{:x}".format(int(hashlib.sha256().hexdigest(), 16) + 1)
+
+        backend = DiskBackend(os.path.dirname(filepath))
+        with pytest.raises(ChecksumValidationError):
+            with backend.read_contextmanager(
+                    os.path.basename(filepath),
+                    expected_checksum) as cm:
+                assert cm.read() == data
+
+
+def test_reentrant(tmpdir):
+    with _test_checksum_setup(tmpdir) as setupdata:
+        filepath, data, expected_checksum = setupdata
+
+        backend = DiskBackend(os.path.dirname(filepath))
+        with backend.read_contextmanager(os.path.basename(filepath), expected_checksum) as cm0:
+            data0 = cm0.read(1)
+            with backend.read_contextmanager(
+                    os.path.basename(filepath),
+                    expected_checksum) as cm1:
+                data1 = cm1.read()
+
+            data0 = data0 + cm0.read()
+
+            assert data == data0
+            assert data == data1
+
+
+@contextlib.contextmanager
+def _test_checksum_setup(tmpdir: Path):
+    """
+    Write some random data to a temporary file and yield its path, the data, and the checksum of
+    the data.
+    """
+    # write the file
+    data = os.urandom(1024)
+
+    expected_checksum = hashlib.sha256(data).hexdigest()
+
+    with tempfile.NamedTemporaryFile(dir=fspath(tmpdir), delete=False) as tfh:
+        tfh.write(data)
+
+    yield tfh.name, data, expected_checksum

--- a/tests/io_/v0_0_0/test_http_backend.py
+++ b/tests/io_/v0_0_0/test_http_backend.py
@@ -94,11 +94,10 @@ class TestHttpBackend(unittest.TestCase):
 
         expected_checksum = hashlib.sha256(data).hexdigest()
 
-        with tempfile.NamedTemporaryFile(dir=tempdir) as tfh:
+        with tempfile.NamedTemporaryFile(dir=tempdir, delete=False) as tfh:
             tfh.write(data)
-            tfh.flush()
 
-            yield os.path.basename(tfh.name), data, expected_checksum
+        yield os.path.basename(tfh.name), data, expected_checksum
 
     def test_error(self):
         """

--- a/tests/io_/v0_0_0/test_missing_shape.py
+++ b/tests/io_/v0_0_0/test_missing_shape.py
@@ -37,19 +37,19 @@ class TestMissingShape(unittest.TestCase):
                 tile.numpy_array[hyb, ch] = 1
                 image.add_tile(tile)
 
-        with tempfile.TemporaryDirectory() as tempdir, \
-                tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
-            partition_file_path = Path(partition_file.name)
-            partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                image, partition_file_path.as_uri())
+        with tempfile.TemporaryDirectory() as tempdir:
+            with tempfile.NamedTemporaryFile(
+                    suffix=".json", dir=tempdir, delete=False) as partition_file:
+                partition_file_path = Path(partition_file.name)
+                partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
+                    image, partition_file_path.as_uri())
 
-            # remove the shape information from the tiles.
-            for tile in partition_doc[TileSetKeys.TILES]:
-                del tile[TileKeys.TILE_SHAPE]
+                # remove the shape information from the tiles.
+                for tile in partition_doc[TileSetKeys.TILES]:
+                    del tile[TileKeys.TILE_SHAPE]
 
-            writer = codecs.getwriter("utf-8")
-            json.dump(partition_doc, writer(partition_file))
-            partition_file.flush()
+                writer = codecs.getwriter("utf-8")
+                json.dump(partition_doc, writer(partition_file))
 
             loaded = slicedimage.Reader.parse_doc(
                 partition_file_path.name, partition_file_path.parent.as_uri())

--- a/tests/io_/v0_0_0/test_write.py
+++ b/tests/io_/v0_0_0/test_write.py
@@ -41,14 +41,14 @@ class TestWrite(unittest.TestCase):
                 tile.numpy_array[hyb, ch] = 1
                 image.add_tile(tile)
 
-        with tempfile.TemporaryDirectory() as tempdir, \
-                tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
-            partition_file_path = Path(partition_file.name)
-            partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                image, partition_file_path.as_uri())
-            writer = codecs.getwriter("utf-8")
-            json.dump(partition_doc, writer(partition_file))
-            partition_file.flush()
+        with tempfile.TemporaryDirectory() as tempdir:
+            with tempfile.NamedTemporaryFile(
+                    suffix=".json", dir=tempdir, delete=False) as partition_file:
+                partition_file_path = Path(partition_file.name)
+                partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
+                    image, partition_file_path.as_uri())
+                writer = codecs.getwriter("utf-8")
+                json.dump(partition_doc, writer(partition_file))
 
             loaded = slicedimage.Reader.parse_doc(
                 partition_file_path.name, partition_file_path.parent.as_uri())
@@ -94,14 +94,14 @@ class TestWrite(unittest.TestCase):
         collection = slicedimage.Collection()
         collection.add_partition("fov002", image)
 
-        with tempfile.TemporaryDirectory() as tempdir, \
-                tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
-            partition_file_path = Path(partition_file.name)
-            partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                collection, partition_file_path.as_uri())
-            writer = codecs.getwriter("utf-8")
-            json.dump(partition_doc, writer(partition_file))
-            partition_file.flush()
+        with tempfile.TemporaryDirectory() as tempdir:
+            with tempfile.NamedTemporaryFile(
+                    suffix=".json", dir=tempdir, delete=False) as partition_file:
+                partition_file_path = Path(partition_file.name)
+                partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
+                    collection, partition_file_path.as_uri())
+                writer = codecs.getwriter("utf-8")
+                json.dump(partition_doc, writer(partition_file))
 
             loaded = slicedimage.Reader.parse_doc(
                 partition_file_path.name, partition_file_path.parent.as_uri())
@@ -169,16 +169,15 @@ class TestWrite(unittest.TestCase):
                 {"cache": {"size_limit": 0}},  # disabled
             )
 
-            with tempfile.TemporaryDirectory() as output_tempdir, \
-                    tempfile.NamedTemporaryFile(
-                        suffix=".json", dir=output_tempdir) as partition_file:
-                partition_file_path = Path(partition_file.name)
-                partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                    image, partition_file_path.as_uri())
+            with tempfile.TemporaryDirectory() as output_tempdir:
+                with tempfile.NamedTemporaryFile(
+                        suffix=".json", dir=output_tempdir, delete=False) as partition_file:
+                    partition_file_path = Path(partition_file.name)
+                    partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
+                        image, partition_file_path.as_uri())
 
-                writer = codecs.getwriter("utf-8")
-                json.dump(partition_doc, writer(partition_file))
-                partition_file.flush()
+                    writer = codecs.getwriter("utf-8")
+                    json.dump(partition_doc, writer(partition_file))
 
                 loaded = slicedimage.Reader.parse_doc(
                     partition_file_path.name, partition_file_path.parent.as_uri())
@@ -208,15 +207,15 @@ class TestWrite(unittest.TestCase):
                 tile.numpy_array[hyb, ch] = 1
                 image.add_tile(tile)
 
-        with tempfile.TemporaryDirectory() as tempdir, \
-                tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
-            # create the tileset and save it.
-            partition_file_path = Path(partition_file.name)
-            partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                image, partition_file_path.as_uri(), tile_format=ImageFormat.TIFF)
-            writer = codecs.getwriter("utf-8")
-            json.dump(partition_doc, writer(partition_file))
-            partition_file.flush()
+        with tempfile.TemporaryDirectory() as tempdir:
+            with tempfile.NamedTemporaryFile(
+                    suffix=".json", dir=tempdir, delete=False) as partition_file:
+                # create the tileset and save it.
+                partition_file_path = Path(partition_file.name)
+                partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
+                    image, partition_file_path.as_uri(), tile_format=ImageFormat.TIFF)
+                writer = codecs.getwriter("utf-8")
+                json.dump(partition_doc, writer(partition_file))
 
             # construct a URL to the tileset we wrote, and load the tileset.
             loaded = slicedimage.Reader.parse_doc(

--- a/tests/io_/v0_1_0/test_caching_backend.py
+++ b/tests/io_/v0_1_0/test_caching_backend.py
@@ -134,11 +134,10 @@ class TestCachingBackend(unittest.TestCase):
 
         expected_checksum = hashlib.sha256(data).hexdigest()
 
-        with tempfile.NamedTemporaryFile(dir=tempdir) as tfh:
+        with tempfile.NamedTemporaryFile(dir=tempdir, delete=False) as tfh:
             tfh.write(data)
-            tfh.flush()
 
-            yield os.path.basename(tfh.name), data, expected_checksum
+        yield os.path.basename(tfh.name), data, expected_checksum
 
 
 if __name__ == "__main__":

--- a/tests/io_/v0_1_0/test_disk_backend.py
+++ b/tests/io_/v0_1_0/test_disk_backend.py
@@ -2,69 +2,68 @@ import contextlib
 import hashlib
 import os
 import tempfile
-import unittest
+from pathlib import Path
 
+import pytest
+
+from slicedimage._compat import fspath
 from slicedimage.backends import ChecksumValidationError, DiskBackend
 
 
-class TestDiskBackend(unittest.TestCase):
-    def test_checksum_good(self):
-        with self._test_checksum_setup() as setupdata:
-            filepath, data, expected_checksum = setupdata
+def test_checksum_good(tmpdir):
+    with _test_checksum_setup(tmpdir) as setupdata:
+        filepath, data, expected_checksum = setupdata
 
-            backend = DiskBackend(os.path.dirname(filepath))
-            with backend.read_contextmanager(os.path.basename(filepath), expected_checksum) as cm:
-                self.assertEqual(cm.read(), data)
-
-    def test_checksum_bad(self):
-        with self._test_checksum_setup() as setupdata:
-            filepath, data, expected_checksum = setupdata
-
-            # make the hash incorrect
-            expected_checksum = "{:x}".format(int(hashlib.sha256().hexdigest(), 16) + 1)
-
-            backend = DiskBackend(os.path.dirname(filepath))
-            with self.assertRaises(ChecksumValidationError):
-                with backend.read_contextmanager(
-                        os.path.basename(filepath),
-                        expected_checksum) as cm:
-                    self.assertEqual(cm.read(), data)
-
-    def test_reentrant(self):
-        with self._test_checksum_setup() as setupdata:
-            filepath, data, expected_checksum = setupdata
-
-            backend = DiskBackend(os.path.dirname(filepath))
-            with backend.read_contextmanager(os.path.basename(filepath), expected_checksum) as cm0:
-                data0 = cm0.read(1)
-                with backend.read_contextmanager(
-                        os.path.basename(filepath),
-                        expected_checksum) as cm1:
-                    data1 = cm1.read()
-
-                data0 = data0 + cm0.read()
-
-                self.assertEqual(data, data0)
-                self.assertEqual(data, data1)
-
-    @staticmethod
-    @contextlib.contextmanager
-    def _test_checksum_setup():
-        """
-        Write some random data to a temporary file and yield its path, the data, and the checksum of
-        the data.
-        """
-        # write the file
-        data = os.urandom(1024)
-
-        expected_checksum = hashlib.sha256(data).hexdigest()
-
-        with tempfile.NamedTemporaryFile() as tfh:
-            tfh.write(data)
-            tfh.flush()
-
-            yield tfh.name, data, expected_checksum
+        backend = DiskBackend(os.path.dirname(filepath))
+        with backend.read_contextmanager(os.path.basename(filepath), expected_checksum) as cm:
+            assert cm.read() == data
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_checksum_bad(tmpdir):
+    with _test_checksum_setup(tmpdir) as setupdata:
+        filepath, data, expected_checksum = setupdata
+
+        # make the hash incorrect
+        expected_checksum = "{:x}".format(int(hashlib.sha256().hexdigest(), 16) + 1)
+
+        backend = DiskBackend(os.path.dirname(filepath))
+        with pytest.raises(ChecksumValidationError):
+            with backend.read_contextmanager(
+                    os.path.basename(filepath),
+                    expected_checksum) as cm:
+                assert cm.read() == data
+
+
+def test_reentrant(tmpdir):
+    with _test_checksum_setup(tmpdir) as setupdata:
+        filepath, data, expected_checksum = setupdata
+
+        backend = DiskBackend(os.path.dirname(filepath))
+        with backend.read_contextmanager(os.path.basename(filepath), expected_checksum) as cm0:
+            data0 = cm0.read(1)
+            with backend.read_contextmanager(
+                    os.path.basename(filepath),
+                    expected_checksum) as cm1:
+                data1 = cm1.read()
+
+            data0 = data0 + cm0.read()
+
+            assert data == data0
+            assert data == data1
+
+
+@contextlib.contextmanager
+def _test_checksum_setup(tmpdir: Path):
+    """
+    Write some random data to a temporary file and yield its path, the data, and the checksum of
+    the data.
+    """
+    # write the file
+    data = os.urandom(1024)
+
+    expected_checksum = hashlib.sha256(data).hexdigest()
+
+    with tempfile.NamedTemporaryFile(dir=fspath(tmpdir), delete=False) as tfh:
+        tfh.write(data)
+
+    yield tfh.name, data, expected_checksum

--- a/tests/io_/v0_1_0/test_http_backend.py
+++ b/tests/io_/v0_1_0/test_http_backend.py
@@ -99,11 +99,10 @@ def _test_checksum_setup(tempdir):
 
     expected_checksum = hashlib.sha256(data).hexdigest()
 
-    with tempfile.NamedTemporaryFile(dir=tempdir) as tfh:
+    with tempfile.NamedTemporaryFile(dir=tempdir, delete=False) as tfh:
         tfh.write(data)
-        tfh.flush()
 
-        yield os.path.basename(tfh.name), data, expected_checksum
+    yield os.path.basename(tfh.name), data, expected_checksum
 
 
 def test_error(http_server):

--- a/tests/io_/v0_1_0/test_missing_shape.py
+++ b/tests/io_/v0_1_0/test_missing_shape.py
@@ -37,19 +37,19 @@ class TestMissingShape(unittest.TestCase):
                 tile.numpy_array[hyb, ch] = 1
                 image.add_tile(tile)
 
-        with tempfile.TemporaryDirectory() as tempdir, \
-                tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
-            partition_file_path = Path(partition_file.name)
-            partition_doc = slicedimage.v0_1_0.Writer().generate_partition_document(
-                image, partition_file_path.as_uri())
+        with tempfile.TemporaryDirectory() as tempdir:
+            with tempfile.NamedTemporaryFile(
+                    suffix=".json", dir=tempdir, delete=False) as partition_file:
+                partition_file_path = Path(partition_file.name)
+                partition_doc = slicedimage.v0_1_0.Writer().generate_partition_document(
+                    image, partition_file_path.as_uri())
 
-            # remove the shape information from the tiles.
-            for tile in partition_doc[TileSetKeys.TILES]:
-                del tile[TileKeys.TILE_SHAPE]
+                # remove the shape information from the tiles.
+                for tile in partition_doc[TileSetKeys.TILES]:
+                    del tile[TileKeys.TILE_SHAPE]
 
-            writer = codecs.getwriter("utf-8")
-            json.dump(partition_doc, writer(partition_file))
-            partition_file.flush()
+                writer = codecs.getwriter("utf-8")
+                json.dump(partition_doc, writer(partition_file))
 
             loaded = slicedimage.Reader.parse_doc(
                 partition_file_path.name, partition_file_path.parent.as_uri())

--- a/tests/io_/v0_1_0/test_write.py
+++ b/tests/io_/v0_1_0/test_write.py
@@ -42,14 +42,14 @@ class TestWrite(unittest.TestCase):
                 tile.numpy_array[hyb, ch] = 1
                 image.add_tile(tile)
 
-        with tempfile.TemporaryDirectory() as tempdir, \
-                tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
-            partition_file_path = Path(partition_file.name)
-            partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                image, partition_file_path.as_uri())
-            writer = codecs.getwriter("utf-8")
-            json.dump(partition_doc, writer(partition_file))
-            partition_file.flush()
+        with tempfile.TemporaryDirectory() as tempdir:
+            with tempfile.NamedTemporaryFile(
+                    suffix=".json", dir=tempdir, delete=False) as partition_file:
+                partition_file_path = Path(partition_file.name)
+                partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
+                    image, partition_file_path.as_uri())
+                writer = codecs.getwriter("utf-8")
+                json.dump(partition_doc, writer(partition_file))
 
             loaded = slicedimage.Reader.parse_doc(
                 partition_file_path.name, partition_file_path.parent.as_uri())
@@ -95,14 +95,14 @@ class TestWrite(unittest.TestCase):
         collection = slicedimage.Collection()
         collection.add_partition("fov002", image)
 
-        with tempfile.TemporaryDirectory() as tempdir, \
-                tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
-            partition_file_path = Path(partition_file.name)
-            partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                collection, partition_file_path.as_uri())
-            writer = codecs.getwriter("utf-8")
-            json.dump(partition_doc, writer(partition_file))
-            partition_file.flush()
+        with tempfile.TemporaryDirectory() as tempdir:
+            with tempfile.NamedTemporaryFile(
+                    suffix=".json", dir=tempdir, delete=False) as partition_file:
+                partition_file_path = Path(partition_file.name)
+                partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
+                    collection, partition_file_path.as_uri())
+                writer = codecs.getwriter("utf-8")
+                json.dump(partition_doc, writer(partition_file))
 
             loaded = slicedimage.Reader.parse_doc(
                 partition_file_path.name, partition_file_path.parent.as_uri())
@@ -170,16 +170,16 @@ class TestWrite(unittest.TestCase):
                 {"cache": {"size_limit": 0}},  # disabled
             )
 
-            with tempfile.TemporaryDirectory() as output_tempdir, \
-                    tempfile.NamedTemporaryFile(
-                        suffix=".json", dir=output_tempdir) as partition_file:
-                partition_file_path = Path(partition_file.name)
-                partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                    image, partition_file_path.as_uri())
+            with tempfile.TemporaryDirectory() as output_tempdir:
+                with tempfile.NamedTemporaryFile(
+                        suffix=".json", dir=output_tempdir, delete=False) as partition_file:
+                    partition_file_path = Path(partition_file.name)
+                    partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
+                        image, partition_file_path.as_uri())
 
-                writer = codecs.getwriter("utf-8")
-                json.dump(partition_doc, writer(partition_file))
-                partition_file.flush()
+                    writer = codecs.getwriter("utf-8")
+                    json.dump(partition_doc, writer(partition_file))
+                    partition_file.flush()
 
                 loaded = slicedimage.Reader.parse_doc(
                     partition_file_path.name, partition_file_path.parent.as_uri())
@@ -209,15 +209,16 @@ class TestWrite(unittest.TestCase):
                 tile.numpy_array[hyb, ch] = 1
                 image.add_tile(tile)
 
-        with tempfile.TemporaryDirectory() as tempdir, \
-                tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
-            partition_file_path = Path(partition_file.name)
-            # create the tileset and save it.
-            partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                image, partition_file_path.as_uri(), tile_format=ImageFormat.TIFF)
-            writer = codecs.getwriter("utf-8")
-            json.dump(partition_doc, writer(partition_file))
-            partition_file.flush()
+        with tempfile.TemporaryDirectory() as tempdir:
+            with tempfile.NamedTemporaryFile(
+                    suffix=".json", dir=tempdir, delete=False) as partition_file:
+                partition_file_path = Path(partition_file.name)
+                # create the tileset and save it.
+                partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
+                    image, partition_file_path.as_uri(), tile_format=ImageFormat.TIFF)
+                writer = codecs.getwriter("utf-8")
+                json.dump(partition_doc, writer(partition_file))
+                partition_file.flush()
 
             # construct a URL to the tileset we wrote, and load the tileset.
             loaded = slicedimage.Reader.parse_doc(
@@ -280,17 +281,17 @@ class TestWrite(unittest.TestCase):
                 delete=False,
             )
 
-        with tempfile.TemporaryDirectory() as tempdir, \
-                tempfile.NamedTemporaryFile(suffix=".json", dir=tempdir) as partition_file:
-            partition_file_path = Path(partition_file.name)
-            partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                collection, partition_file_path.as_uri(),
-                partition_path_generator=partition_path_generator,
-                tile_opener=tile_opener,
-            )
-            writer = codecs.getwriter("utf-8")
-            json.dump(partition_doc, writer(partition_file))
-            partition_file.flush()
+        with tempfile.TemporaryDirectory() as tempdir:
+            with tempfile.NamedTemporaryFile(
+                    suffix=".json", dir=tempdir, delete=False) as partition_file:
+                partition_file_path = Path(partition_file.name)
+                partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
+                    collection, partition_file_path.as_uri(),
+                    partition_path_generator=partition_path_generator,
+                    tile_opener=tile_opener,
+                )
+                writer = codecs.getwriter("utf-8")
+                json.dump(partition_doc, writer(partition_file))
 
             loaded = slicedimage.Reader.parse_doc(
                 partition_file_path.name, partition_file_path.parent.as_uri())


### PR DESCRIPTION
It's not possible, using python stdlib, to open a file in Windows for write and read simultaneously.  A common idiom in the test code is to set up a temporary file using `with tempfile.NamedTemporaryFile()`, write some content to it, and then switch to the test code, and then cleaning up the temp file when the `with` statement goes out of scope.

This is incompatible with Windows, so we instead just create the temporary file, write out the necessary contents, and then close it (and not delete it).  We rely on the temporary directory cleanup to ensure that the files eventually get cleaned up.

On the */test_disk_backend.py, we were not using a temporary directory, so we add that.

Test plan: works on windows
Depends on #117 
Part of https://github.com/spacetx/starfish/issues/1296