### PR TITLE
[easy] Reverse context unwind

### DIFF
--- a/tests/io_/v0_0_0/test_caching_backend.py
+++ b/tests/io_/v0_0_0/test_caching_backend.py
@@ -55,7 +55,7 @@ class TestCachingBackend(unittest.TestCase):
         self.caching_backend = CachingBackend(self.cachedir.name, self.http_backend)
 
     def tearDown(self):
-        for context in self.contexts:
+        for context in reversed(self.contexts):
             context.__exit__(*sys.exc_info())
 
     def test_checksum_good(self):

--- a/tests/io_/v0_0_0/test_http_backend.py
+++ b/tests/io_/v0_0_0/test_http_backend.py
@@ -52,7 +52,7 @@ class TestHttpBackend(unittest.TestCase):
         self.http_backend = HttpBackend("http://0.0.0.0:{port}".format(port=self.port))
 
     def tearDown(self):
-        for context in self.contexts:
+        for context in reversed(self.contexts):
             context.__exit__(*sys.exc_info())
 
     def test_checksum_good(self):

--- a/tests/io_/v0_1_0/test_caching_backend.py
+++ b/tests/io_/v0_1_0/test_caching_backend.py
@@ -56,7 +56,7 @@ class TestCachingBackend(unittest.TestCase):
         self.caching_backend = CachingBackend(self.cachedir.name, self.http_backend)
 
     def tearDown(self):
-        for context in self.contexts:
+        for context in reversed(self.contexts):
             context.__exit__(*sys.exc_info())
 
     def test_checksum_good(self):


### PR DESCRIPTION
We have a mechanism for tracking multiple context managers for unit test setup and teardown.  For unwinding them context managers, we should unwind them in the reverse order they are created.

On POSIX systems, this does not matter, as we can hold file handles to files that are deleted.  However, on Windows, the ordering is critical as one cannot delete files that are still held open.

In the case where we create a temporary directory, and then spin up a http server to listen to requests at that directory, we need to kill the process _before_ we clean up the temporary directory.

Test plan: works on windows
Part of https://github.com/spacetx/starfish/issues/1296