### PR TITLE
[easy] disable reentrant tests

### DIFF
--- a/tests/io_/v0_0_0/test_caching_backend.py
+++ b/tests/io_/v0_0_0/test_caching_backend.py
@@ -108,6 +108,8 @@ class TestCachingBackend(unittest.TestCase):
                 self.assertEqual(cm.read(), data)
 
     def test_reentrant(self):
+        if os.name == "nt":
+            self.skipTest("Cannot run reentrant test on Windows")
         with self._test_checksum_setup(self.tempdir.name) as setupdata:
             filename, data, expected_checksum = setupdata
 

--- a/tests/io_/v0_1_0/test_caching_backend.py
+++ b/tests/io_/v0_1_0/test_caching_backend.py
@@ -109,6 +109,8 @@ class TestCachingBackend(unittest.TestCase):
                 self.assertEqual(cm.read(), data)
 
     def test_reentrant(self):
+        if os.name == "nt":
+            self.skipTest("Cannot run reentrant test on Windows")
         with self._test_checksum_setup(self.tempdir.name) as setupdata:
             filename, data, expected_checksum = setupdata
 


### PR DESCRIPTION
It's not possible on Windows, with standard filesystem calls, to open the same file twice.  Reentrant tests on the disk backend requires that behavior, so this disables the test on Windows.

Test plan: Windows!
Part of spacetx/starfish#1296