### PR TITLE
Clean up our usage of DiskCache

### DIFF
--- a/tests/io_/v0_0_0/test_caching_backend.py
+++ b/tests/io_/v0_0_0/test_caching_backend.py
@@ -8,8 +8,9 @@ import unittest
 
 import requests
 
-from slicedimage.backends import ChecksumValidationError, HttpBackend, CachingBackend
+from slicedimage.backends import ChecksumValidationError, HttpBackend
 from tests.utils import (
+    ContextualCachingBackend,
     ContextualChildProcess,
     unused_tcp_port,
 )
@@ -52,7 +53,9 @@ class TestCachingBackend(unittest.TestCase):
         self.contexts.append(self.cachedir)
 
         self.http_backend = HttpBackend("http://127.0.0.1:{port}".format(port=self.port))
-        self.caching_backend = CachingBackend(self.cachedir.name, self.http_backend)
+        caching_context = ContextualCachingBackend(self.cachedir.name, self.http_backend)
+        self.caching_backend = caching_context.__enter__()
+        self.contexts.append(caching_context)
 
     def tearDown(self):
         for context in reversed(self.contexts):

--- a/tests/io_/v0_1_0/test_caching_backend.py
+++ b/tests/io_/v0_1_0/test_caching_backend.py
@@ -9,8 +9,9 @@ import unittest
 import requests
 from six import unichr
 
-from slicedimage.backends import ChecksumValidationError, HttpBackend, CachingBackend
+from slicedimage.backends import ChecksumValidationError, HttpBackend
 from tests.utils import (
+    ContextualCachingBackend,
     ContextualChildProcess,
     unused_tcp_port,
 )
@@ -53,7 +54,9 @@ class TestCachingBackend(unittest.TestCase):
         self.contexts.append(self.cachedir)
 
         self.http_backend = HttpBackend("http://127.0.0.1:{port}".format(port=self.port))
-        self.caching_backend = CachingBackend(self.cachedir.name, self.http_backend)
+        caching_context = ContextualCachingBackend(self.cachedir.name, self.http_backend)
+        self.caching_backend = caching_context.__enter__()
+        self.contexts.append(caching_context)
 
     def tearDown(self):
         for context in reversed(self.contexts):

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -2,13 +2,7 @@ import contextlib
 import socket
 
 from tests.utils.contextchild import ContextualChildProcess
-
-
-__all__ = [
-    'ContextualChildProcess',
-    'unused_tcp_port',
-    'build_skeleton_manifest'
-]
+from tests.utils.contextualcachingbackend import ContextualCachingBackend
 
 
 def unused_tcp_port():

--- a/tests/utils/contextualcachingbackend.py
+++ b/tests/utils/contextualcachingbackend.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from typing import Optional
+
+from diskcache import Cache
+
+from slicedimage.backends import CachingBackend
+from slicedimage.backends._base import Backend
+
+
+class ContextualCachingBackend:
+    """
+    Provides a context manager for wrapping a caching backend.  This is required for Windows, where
+    the cache must be closed before we clean up a working directory.
+    """
+    def __init__(self, cachedir: Path, authoritative_backend: Backend):
+        self.cachedir = cachedir
+        self.authoritative_backend = authoritative_backend
+
+    def __enter__(self):
+        return CachingBackend(self.cachedir, self.authoritative_backend)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        cache_obj = CachingBackend._CACHE.pop(self.cachedir, None)  # type: Optional[Cache]
+        if cache_obj is not None:
+            cache_obj.close()


### PR DESCRIPTION
In our caching tests, we create a temporary directory, and then initialize a cache in that temporary directory.  The issue is that the cache handle holds an open file handle, and on Windows, the cleanup of the temporary directory fails if the cache handle still exists.

The fix is to add a context manager to remove the cache handle.

Test plan: works on windows
Depends on #115 
Part of https://github.com/spacetx/starfish/issues/1296