### PR TITLE
Fix path composition in old write_to_path API

### DIFF
--- a/slicedimage/io/_base.py
+++ b/slicedimage/io/_base.py
@@ -22,7 +22,6 @@ from packaging import version
 
 from slicedimage.url.resolve import resolve_url
 from slicedimage._collection import Collection
-from slicedimage._compat import fspath
 from slicedimage._formats import ImageFormat
 from slicedimage._tile import Tile
 from slicedimage._tileset import TileSet
@@ -131,9 +130,7 @@ class Writer:
         else:
             kwargs['writer_contract'] = WriterContract()
 
-        url = urllib.parse.urlunparse(("file", "", fspath(path), "", "", ""))
-
-        return Writer.write_to_url(partition, url, pretty, version_class, *args, **kwargs)
+        return Writer.write_to_url(partition, path.as_uri(), pretty, version_class, *args, **kwargs)
 
     @staticmethod
     def write_to_url(


### PR DESCRIPTION
`as_uri()` is a better API than urlunparse, which doesn't handle Windows backslashes.

Part of https://github.com/spacetx/starfish/issues/1493