### PR TITLE
Ensure that Tiles are picklable

### DIFF
--- a/slicedimage/backends/_caching.py
+++ b/slicedimage/backends/_caching.py
@@ -69,4 +69,7 @@ class _CachingBackendContextManager:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.handle is not None:
-            return self.handle.__exit__(exc_type, exc_val, exc_tb)
+            try:
+                return self.handle.__exit__(exc_type, exc_val, exc_tb)
+            finally:
+                self.handle = None

--- a/slicedimage/backends/_disk.py
+++ b/slicedimage/backends/_disk.py
@@ -27,4 +27,7 @@ class _FileLikeContextManager:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.handle is not None:
-            return self.handle.__exit__(exc_type, exc_val, exc_tb)
+            try:
+                return self.handle.__exit__(exc_type, exc_val, exc_tb)
+            finally:
+                self.handle = None

--- a/slicedimage/backends/_http.py
+++ b/slicedimage/backends/_http.py
@@ -41,4 +41,7 @@ class _UrlContextManager:
         return self.handle.__enter__()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        return self.handle.__exit__(exc_type, exc_val, exc_tb)
+        try:
+            return self.handle.__exit__(exc_type, exc_val, exc_tb)
+        finally:
+            self.handle = None

--- a/slicedimage/backends/_s3.py
+++ b/slicedimage/backends/_s3.py
@@ -56,4 +56,7 @@ class _S3ContextManager:
         return self.buffer.__enter__()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        return self.buffer.__exit__(exc_type, exc_val, exc_tb)
+        try:
+            return self.buffer.__exit__(exc_type, exc_val, exc_tb)
+        finally:
+            self.buffer = None

--- a/slicedimage/io/_v0_0_0.py
+++ b/slicedimage/io/_v0_0_0.py
@@ -81,17 +81,8 @@ class v0_0_0:
                         extras=tile_doc.get(TileKeys.EXTRAS, None),
                     )
 
-                    def future_maker(_source_fh_contextmanager, _tile_format):
-                        """Produces a future that reads from a file and decodes according to the
-                        specified file format."""
-                        def _actual_future():
-                            with _source_fh_contextmanager as fh:
-                                return _tile_format.reader_func(fh)
-
-                        return _actual_future
-
                     tile.set_numpy_array_future(
-                        future_maker(
+                        SourceFileFuture(
                             backend.read_contextmanager(name, checksum_sha256=checksum),
                             tile_format))
                     result.add_tile(tile)
@@ -168,3 +159,15 @@ class v0_0_0:
                     json_doc[TileSetKeys.TILES].append(tiledoc)
 
                 return json_doc
+
+
+class SourceFileFuture:
+    """Produces a future that reads from a file and decodes according to the
+    specified file format."""
+    def __init__(self, source_fh_contextmanager, tile_format: ImageFormat):
+        self.source_fh_contextmanager = source_fh_contextmanager
+        self.tile_format = tile_format
+
+    def __call__(self, *args, **kwargs):
+        with self.source_fh_contextmanager as fh:
+            return self.tile_format.reader_func(fh)


### PR DESCRIPTION
1. File handles are not picklable, even if they are closed.  Therefore, `self.handle` should be cleared after `__exit__` is called.
2. Callables with bound variables not defined locally cannot be pickled.  The same purpose can be achieved by a class that has a `__call__` method.

Test plan: Successfully pickled an ImageStack in starfish.