### PR TITLE
Add png reader/writer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pathlib;python_version<"3.0"
 numpy
 requests
 tifffile
+imageio

--- a/slicedimage/_formats.py
+++ b/slicedimage/_formats.py
@@ -54,7 +54,10 @@ def tiff_writer():
 def png_writer():
     from imageio import imwrite
 
-    return imwrite
+    def writer(f, arr):
+        return imwrite(to_file_obj_or_str(f), arr, format='png')
+
+    return writer
 
 
 def numpy_writer():

--- a/slicedimage/_formats.py
+++ b/slicedimage/_formats.py
@@ -1,5 +1,6 @@
 import enum
 from pathlib import Path
+
 from ._compat import fspath
 
 
@@ -20,6 +21,13 @@ def tiff_reader():
             return tiff.asarray(maxworkers=1)
 
     return reader
+
+
+def png_reader():
+    from imageio import imread
+
+    return imread
+
 
 def numpy_reader():
     # lazy load numpy
@@ -43,6 +51,12 @@ def tiff_writer():
     return writer
 
 
+def png_writer():
+    from imageio import imwrite
+
+    return imwrite
+
+
 def numpy_writer():
     """
     Return a method that accepts (file, array) and saves it to the file.  File may be a file-like
@@ -63,6 +77,7 @@ class ImageFormat(enum.Enum):
     """
     TIFF = (tiff_reader, tiff_writer, "tiff", {"tif"})
     NUMPY = (numpy_reader, numpy_writer, "npy", None)
+    PNG = (png_reader, png_writer, "png", None)
 
     def __init__(
             self,

--- a/tests/io_/v0_0_0/test_reader.py
+++ b/tests/io_/v0_0_0/test_reader.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import imageio
 import tifffile
 import numpy as np
 from slicedimage._compat import fspath
@@ -89,6 +90,46 @@ class TestFormats(unittest.TestCase):
                     },
                     "file": "tile.tiff",
                     "format": "tiff",
+                },
+            )
+            with open(fspath(tempdir_path / "tileset.json"), "w") as fh:
+                fh.write(json.dumps(manifest))
+
+            result = slicedimage.Reader.parse_doc("tileset.json", tempdir_path.as_uri())
+
+            self.assertTrue(np.array_equal(list(result.tiles())[0].numpy_array, data))
+
+    def test_png(self):
+        """
+        Generate a tileset consisting of a single TIFF tile, and then read it.
+        """
+        with tempfile.TemporaryDirectory() as tempdir:
+            tempdir_path = Path(tempdir)
+            # write the tiff file
+            data = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
+            imageio.imwrite(os.path.join(tempdir, "tile.png"), data)
+
+            # TODO: (ttung) We should really be producing a tileset programmatically and writing it
+            # disk.  However, our current write path only produces numpy output files.
+            manifest = build_skeleton_manifest()
+            manifest['tiles'].append(
+                {
+                    "coordinates": {
+                        DimensionNames.X.value: [
+                            0.0,
+                            0.0001,
+                        ],
+                        DimensionNames.Y.value: [
+                            0.0,
+                            0.0001,
+                        ]
+                    },
+                    "indices": {
+                        "hyb": 0,
+                        "ch": 0,
+                    },
+                    "file": "tile.png",
+                    "format": "PNG",
                 },
             )
             with open(fspath(tempdir_path / "tileset.json"), "w") as fh:

--- a/tests/io_/v0_1_0/test_reader.py
+++ b/tests/io_/v0_1_0/test_reader.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import imageio
 import tifffile
 import numpy as np
 from slicedimage._compat import fspath
@@ -89,6 +90,46 @@ class TestFormats(unittest.TestCase):
                     },
                     "file": "tile.tiff",
                     "format": "tiff",
+                },
+            )
+            with open(fspath(tempdir_path / "tileset.json"), "w") as fh:
+                fh.write(json.dumps(manifest))
+
+            result = slicedimage.Reader.parse_doc("tileset.json", tempdir_path.as_uri())
+
+            self.assertTrue(np.array_equal(list(result.tiles())[0].numpy_array, data))
+
+    def test_png(self):
+        """
+        Generate a tileset consisting of a single PNG tile, and then read it.
+        """
+        with tempfile.TemporaryDirectory() as tempdir:
+            tempdir_path = Path(tempdir)
+            # write the tiff file
+            data = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
+            imageio.imwrite(os.path.join(tempdir, "tile.png"), data)
+
+            # TODO: (ttung) We should really be producing a tileset programmatically and writing it
+            # disk.  However, our current write path only produces numpy output files.
+            manifest = build_skeleton_manifest()
+            manifest['tiles'].append(
+                {
+                    "coordinates": {
+                        DimensionNames.X.value: [
+                            0.0,
+                            0.0001,
+                        ],
+                        DimensionNames.Y.value: [
+                            0.0,
+                            0.0001,
+                        ]
+                    },
+                    "indices": {
+                        "hyb": 0,
+                        "ch": 0,
+                    },
+                    "file": "tile.png",
+                    "format": "PNG",
                 },
             )
             with open(fspath(tempdir_path / "tileset.json"), "w") as fh:

--- a/tests/io_/v0_1_0/test_write.py
+++ b/tests/io_/v0_1_0/test_write.py
@@ -241,6 +241,61 @@ class TestWrite(unittest.TestCase):
                     self.assertEqual(tiles[0].numpy_array.all(), expected.all())
                     self.assertIsNotNone(tiles[0].sha256)
 
+    def test_write_png(self):
+        image = slicedimage.TileSet(
+            dimensions=[DimensionNames.X, DimensionNames.Y, "ch", "hyb"],
+            shape={'ch': 2, 'hyb': 2},
+            default_tile_shape={DimensionNames.Y: 120, DimensionNames.X: 80},
+        )
+
+        for hyb in range(2):
+            for ch in range(2):
+                tile = slicedimage.Tile(
+                    coordinates={
+                        DimensionNames.X: (0.0, 0.01),
+                        DimensionNames.Y: (0.0, 0.01),
+                    },
+                    indices={
+                        'hyb': hyb,
+                        'ch': ch,
+                    },
+                )
+                tile.numpy_array = np.zeros((120, 80), dtype=np.uint32)
+                tile.numpy_array[hyb, ch] = 1
+                image.add_tile(tile)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            with tempfile.NamedTemporaryFile(
+                    suffix=".json", dir=tempdir, delete=False) as partition_file:
+                partition_file_path = Path(partition_file.name)
+                # create the tileset and save it.
+                partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
+                    image, partition_file_path.as_uri(), tile_format=ImageFormat.PNG)
+                writer = codecs.getwriter("utf-8")
+                json.dump(partition_doc, writer(partition_file))
+                partition_file.flush()
+
+            # construct a URL to the tileset we wrote, and load the tileset.
+            loaded = slicedimage.Reader.parse_doc(
+                partition_file_path.name, partition_file_path.parent.as_uri())
+
+            # compare the tiles we loaded to the tiles we set up.
+            for hyb in range(2):
+                for ch in range(2):
+                    tiles = [_tile
+                             for _tile in loaded.tiles(
+                                 lambda tile: (
+                                     tile.indices['hyb'] == hyb
+                                     and tile.indices['ch'] == ch))]
+
+                    self.assertEqual(len(tiles), 1)
+
+                    expected = np.zeros((120, 80), dtype=np.uint32)
+                    expected[hyb, ch] = 1
+
+                    self.assertEqual(tiles[0].numpy_array.all(), expected.all())
+                    self.assertIsNotNone(tiles[0].sha256)
+
     def test_multi_directory_write_collection(self):
         """Test that we can write collections with a directory hierarchy."""
         image = slicedimage.TileSet(


### PR DESCRIPTION
This PR adds PNG reader/writer support via `imageio`.

Testing:

- [x] Add reader test
- [x] Add writer test
