### PR TITLE
Fix Windows CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,13 @@ matrix:
   include:
     - os: windows
       language: sh
-      python: "3.7"
       before_install:
-        - choco install python3 make
-        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+        # this hackery is in here because of https://github.com/git-for-windows/git/issues/2291
+        - powershell mkdir "'C:\Program Files\Git\dev'"
+        - ln -s /proc/self/fd /dev/fd
+        - choco install make
+        - choco install python
+        - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
         - python -m pip install --upgrade pip wheel
 install:
   - pip install -r requirements-dev.txt


### PR DESCRIPTION
- choco install python3 will install the latest version of python on the 3.x line, so since 3.8 came out, this breaks.
- https://github.com/git-for-windows/git/issues/2291 broke codecov reporting, so there's a workaround until git-for-windows cuts a new release.

Test plan: watch Windows travis build succeed