### PR TITLE
Better tests for file formats

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,5 @@ mypy
 pytest>=4.4.0
 pytest-cov
 pytest-xdist
+python-magic
 -r requirements.txt

--- a/tests/io_/v0_0_0/test_reader.py
+++ b/tests/io_/v0_0_0/test_reader.py
@@ -1,17 +1,8 @@
 import collections
-import json
-import os
-import tempfile
 import unittest
 from pathlib import Path
 
-import imageio
-import numpy as np
-from slicedimage._compat import fspath
-
 import slicedimage
-from slicedimage._dimensions import DimensionNames
-from tests.utils import build_skeleton_manifest
 
 baseurl = Path(__file__).parent.resolve().as_uri()
 
@@ -54,123 +45,6 @@ class TestReader(unittest.TestCase):
                 self.assertTrue(isinstance(value, collections.Hashable))
             for value in tile.indices.values():
                 self.assertTrue(isinstance(value, collections.Hashable))
-
-
-class TestFormats(unittest.TestCase):
-    def test_tiff(self):
-        """
-        Generate a tileset consisting of a single TIFF tile, and then read it.
-        """
-        with tempfile.TemporaryDirectory() as tempdir:
-            tempdir_path = Path(tempdir)
-            # write the tiff file
-            data = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
-            imageio.imwrite(os.path.join(tempdir, "tile.tiff"), data, format="tiff")
-
-            # TODO: (ttung) We should really be producing a tileset programmatically and writing it
-            # disk.  However, our current write path only produces numpy output files.
-            manifest = build_skeleton_manifest()
-            manifest['tiles'].append(
-                {
-                    "coordinates": {
-                        DimensionNames.X.value: [
-                            0.0,
-                            0.0001,
-                        ],
-                        DimensionNames.Y.value: [
-                            0.0,
-                            0.0001,
-                        ]
-                    },
-                    "indices": {
-                        "hyb": 0,
-                        "ch": 0,
-                    },
-                    "file": "tile.tiff",
-                    "format": "tiff",
-                },
-            )
-            with open(fspath(tempdir_path / "tileset.json"), "w") as fh:
-                fh.write(json.dumps(manifest))
-
-            result = slicedimage.Reader.parse_doc("tileset.json", tempdir_path.as_uri())
-
-            self.assertTrue(np.array_equal(list(result.tiles())[0].numpy_array, data))
-
-    def test_png(self):
-        """
-        Generate a tileset consisting of a single TIFF tile, and then read it.
-        """
-        with tempfile.TemporaryDirectory() as tempdir:
-            tempdir_path = Path(tempdir)
-            # write the tiff file
-            data = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
-            imageio.imwrite(os.path.join(tempdir, "tile.png"), data)
-
-            # TODO: (ttung) We should really be producing a tileset programmatically and writing it
-            # disk.  However, our current write path only produces numpy output files.
-            manifest = build_skeleton_manifest()
-            manifest['tiles'].append(
-                {
-                    "coordinates": {
-                        DimensionNames.X.value: [
-                            0.0,
-                            0.0001,
-                        ],
-                        DimensionNames.Y.value: [
-                            0.0,
-                            0.0001,
-                        ]
-                    },
-                    "indices": {
-                        "hyb": 0,
-                        "ch": 0,
-                    },
-                    "file": "tile.png",
-                    "format": "PNG",
-                },
-            )
-            with open(fspath(tempdir_path / "tileset.json"), "w") as fh:
-                fh.write(json.dumps(manifest))
-
-            result = slicedimage.Reader.parse_doc("tileset.json", tempdir_path.as_uri())
-
-            self.assertTrue(np.array_equal(list(result.tiles())[0].numpy_array, data))
-
-    def test_numpy(self):
-        """
-        Generate a tileset consisting of a single TIFF tile, and then read it.
-        """
-        image = slicedimage.TileSet(
-            [DimensionNames.X, DimensionNames.Y, "ch", "hyb"],
-            {'ch': 1, 'hyb': 1},
-            {DimensionNames.Y: 120, DimensionNames.X: 80},
-        )
-
-        tile = slicedimage.Tile(
-            {
-                DimensionNames.X: (0.0, 0.01),
-                DimensionNames.Y: (0.0, 0.01),
-            },
-            {
-                'hyb': 0,
-                'ch': 0,
-            },
-        )
-        tile.numpy_array = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
-        image.add_tile(tile)
-
-        with tempfile.TemporaryDirectory() as tempdir:
-            tempdir_path = Path(tempdir)
-            tileset_path = tempdir_path / "tileset.json"
-            partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                image, (tempdir_path / "tileset.json").as_uri())
-            with open(fspath(tileset_path), "w") as fh:
-                json.dump(partition_doc, fh)
-
-            result = slicedimage.Reader.parse_doc("tileset.json", tempdir_path.as_uri())
-
-            self.assertTrue(np.array_equal(list(result.tiles())[0].numpy_array, tile.numpy_array))
 
 
 if __name__ == "__main__":

--- a/tests/io_/v0_1_0/test_reader.py
+++ b/tests/io_/v0_1_0/test_reader.py
@@ -1,17 +1,8 @@
 import collections
-import json
-import os
-import tempfile
 import unittest
 from pathlib import Path
 
-import imageio
-import numpy as np
-from slicedimage._compat import fspath
-
 import slicedimage
-from slicedimage._dimensions import DimensionNames
-from tests.utils import build_skeleton_manifest
 
 baseurl = Path(__file__).parent.resolve().as_uri()
 
@@ -54,123 +45,6 @@ class TestReader(unittest.TestCase):
                 self.assertTrue(isinstance(value, collections.Hashable))
             for value in tile.indices.values():
                 self.assertTrue(isinstance(value, collections.Hashable))
-
-
-class TestFormats(unittest.TestCase):
-    def test_tiff(self):
-        """
-        Generate a tileset consisting of a single TIFF tile, and then read it.
-        """
-        with tempfile.TemporaryDirectory() as tempdir:
-            tempdir_path = Path(tempdir)
-            # write the tiff file
-            data = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
-            imageio.imwrite(os.path.join(tempdir, "tile.tiff"), data, format="tiff")
-
-            # TODO: (ttung) We should really be producing a tileset programmatically and writing it
-            # disk.  However, our current write path only produces numpy output files.
-            manifest = build_skeleton_manifest()
-            manifest['tiles'].append(
-                {
-                    "coordinates": {
-                        DimensionNames.X.value: [
-                            0.0,
-                            0.0001,
-                        ],
-                        DimensionNames.Y.value: [
-                            0.0,
-                            0.0001,
-                        ]
-                    },
-                    "indices": {
-                        "hyb": 0,
-                        "ch": 0,
-                    },
-                    "file": "tile.tiff",
-                    "format": "tiff",
-                },
-            )
-            with open(fspath(tempdir_path / "tileset.json"), "w") as fh:
-                fh.write(json.dumps(manifest))
-
-            result = slicedimage.Reader.parse_doc("tileset.json", tempdir_path.as_uri())
-
-            self.assertTrue(np.array_equal(list(result.tiles())[0].numpy_array, data))
-
-    def test_png(self):
-        """
-        Generate a tileset consisting of a single PNG tile, and then read it.
-        """
-        with tempfile.TemporaryDirectory() as tempdir:
-            tempdir_path = Path(tempdir)
-            # write the tiff file
-            data = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
-            imageio.imwrite(os.path.join(tempdir, "tile.png"), data)
-
-            # TODO: (ttung) We should really be producing a tileset programmatically and writing it
-            # disk.  However, our current write path only produces numpy output files.
-            manifest = build_skeleton_manifest()
-            manifest['tiles'].append(
-                {
-                    "coordinates": {
-                        DimensionNames.X.value: [
-                            0.0,
-                            0.0001,
-                        ],
-                        DimensionNames.Y.value: [
-                            0.0,
-                            0.0001,
-                        ]
-                    },
-                    "indices": {
-                        "hyb": 0,
-                        "ch": 0,
-                    },
-                    "file": "tile.png",
-                    "format": "PNG",
-                },
-            )
-            with open(fspath(tempdir_path / "tileset.json"), "w") as fh:
-                fh.write(json.dumps(manifest))
-
-            result = slicedimage.Reader.parse_doc("tileset.json", tempdir_path.as_uri())
-
-            self.assertTrue(np.array_equal(list(result.tiles())[0].numpy_array, data))
-
-    def test_numpy(self):
-        """
-        Generate a tileset consisting of a single TIFF tile, and then read it.
-        """
-        image = slicedimage.TileSet(
-            [DimensionNames.X, DimensionNames.Y, "ch", "hyb"],
-            {'ch': 1, 'hyb': 1},
-            {DimensionNames.Y: 120, DimensionNames.X: 80},
-        )
-
-        tile = slicedimage.Tile(
-            {
-                DimensionNames.X: (0.0, 0.01),
-                DimensionNames.Y: (0.0, 0.01),
-            },
-            {
-                'hyb': 0,
-                'ch': 0,
-            },
-        )
-        tile.numpy_array = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
-        image.add_tile(tile)
-
-        with tempfile.TemporaryDirectory() as tempdir:
-            tempdir_path = Path(tempdir)
-            partition_file_path = tempdir_path / "tileset.json"
-            partition_doc = slicedimage.v0_0_0.Writer().generate_partition_document(
-                image, partition_file_path.as_uri())
-            with open(fspath(partition_file_path), "w") as fh:
-                json.dump(partition_doc, fh)
-
-            result = slicedimage.Reader.parse_doc("tileset.json", tempdir_path.as_uri())
-
-            self.assertTrue(np.array_equal(list(result.tiles())[0].numpy_array, tile.numpy_array))
 
 
 if __name__ == "__main__":

--- a/tests/io_/v0_1_0/test_write.py
+++ b/tests/io_/v0_1_0/test_write.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import magic
 import numpy as np
 from imageio import imwrite
 from slicedimage._compat import fspath
@@ -223,6 +224,14 @@ class TestWrite(unittest.TestCase):
             loaded = slicedimage.Reader.parse_doc(
                 partition_file_path.name, partition_file_path.parent.as_uri())
 
+            # verify that we wrote some tiffs, and all the tiffs we wrote actually identify as
+            # tiffs.
+            tifffiles = list(Path(tempdir).glob("*.tiff"))
+            assert len(tifffiles) > 0
+            for tifffile in tifffiles:
+                filetype = magic.from_file(fspath(tifffile))
+                assert filetype.lower().startswith("tiff")
+
             # compare the tiles we loaded to the tiles we set up.
             for hyb in range(2):
                 for ch in range(2):
@@ -277,6 +286,13 @@ class TestWrite(unittest.TestCase):
             # construct a URL to the tileset we wrote, and load the tileset.
             loaded = slicedimage.Reader.parse_doc(
                 partition_file_path.name, partition_file_path.parent.as_uri())
+
+            # verify that we wrote some pngs, and all the pngs we wrote actually identify as pngs.
+            pngfiles = list(Path(tempdir).glob("*.png"))
+            assert len(pngfiles) > 0
+            for pngfile in pngfiles:
+                filetype = magic.from_file(fspath(pngfile))
+                assert filetype.lower().startswith("png")
 
             # compare the tiles we loaded to the tiles we set up.
             for hyb in range(2):


### PR DESCRIPTION
1. Remove the tests for file formats in test_reader.  test_write already verifies the write-then-read path.
2. Add test that identifies the tiles using python-magic (backed by libmagic) and asserts they are of the file type we requested.

Test plan: make -j test
Depends on https://github.com/spacetx/slicedimage/pull/127 and https://github.com/kevinyamauchi/slicedimage/pull/1