### PR TITLE
Fix 3D TIFF read/write

### DIFF
--- a/slicedimage/_formats.py
+++ b/slicedimage/_formats.py
@@ -2,10 +2,10 @@ import enum
 
 
 def tiff_reader():
-    from imageio import imread
+    from imageio import volread
 
     def reader(f):
-        return imread(f, format="tiff")
+        return volread(f, format="tiff")
 
     return reader
 
@@ -31,10 +31,15 @@ def tiff_writer():
     Return a method that accepts (file, array) and saves it to the file.  File may be a file-like
     object, str, or pathlib.Path.
     """
-    from imageio import imwrite
+    from imageio import imwrite, volwrite
 
     def writer(f, arr):
-        imwrite(f, arr, format="tiff")
+        if arr.ndim == 2:
+            imwrite(f, arr, format="tiff")
+        elif arr.ndim == 3:
+            volwrite(f, arr, format="tiff")
+        else:
+            raise ValueError("cannot handle {}-dimensional data.".format(arr.ndim))
 
     return writer
 
@@ -43,7 +48,10 @@ def png_writer():
     from imageio import imwrite
 
     def writer(f, arr):
-        return imwrite(f, arr, format="png")
+        if arr.ndim == 2:
+            imwrite(f, arr, format="png")
+        else:
+            raise ValueError("cannot handle {}-dimensional data.".format(arr.ndim))
 
     return writer
 

--- a/tests/test_nd_tiff.py
+++ b/tests/test_nd_tiff.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from slicedimage._formats import tiff_reader, tiff_writer
+
+
+def test_2d_tiff(tmp_path):
+    path = Path(str(tmp_path / "2d.tiff"))
+    data = np.random.random((5, 6))
+    tiff_writer()(path, data)
+    read = tiff_reader()(path)
+    assert np.all(data == read)
+
+
+def test_3d_tiff(tmp_path):
+    path = Path(str(tmp_path / "3d.tiff"))
+    data = np.random.random((5, 6, 7))
+    tiff_writer()(path, data)
+    read = tiff_reader()(path)
+    assert np.all(data == read)
+
+
+def test_4d_tiff(tmp_path):
+    path = Path(str(tmp_path / "4d.tiff"))
+    data = np.random.random((5, 6, 7, 8))
+    with pytest.raises(ValueError):
+        tiff_writer()(path, data)


### PR DESCRIPTION
Switching tiff to using imageio broke 3D tiff operations, as imageio handles 3D images through `volread` and `volwrite`.  This PR updates tiff handling to use those methods when appropriate.

Test plan: add tests to read and write 2d and 3d tiffs.