### PR TITLE
Fix windows build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
         - choco install python
         - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
         - python -m pip install --upgrade pip wheel
+        - python -m pip install python-magic-win64
 install:
   - pip install -r requirements-dev.txt
   - pip install -e .

--- a/tests/io_/v0_1_0/test_write.py
+++ b/tests/io_/v0_1_0/test_write.py
@@ -2,11 +2,11 @@ import codecs
 import hashlib
 import json
 import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-import magic
 import numpy as np
 from imageio import imwrite
 from slicedimage._compat import fspath
@@ -15,6 +15,11 @@ import slicedimage
 from slicedimage import ImageFormat
 from slicedimage._dimensions import DimensionNames
 from tests.utils import build_skeleton_manifest
+
+if sys.platform == "win32":
+    from winmagic import magic
+else:
+    import magic
 
 baseurl = Path(__file__).parent.resolve().as_uri()
 


### PR DESCRIPTION
python-magic doesn't work for win32.  python-magic-win64 appears to be the substitute for Windows.

Test plan: travis