### PR TITLE
[easy] fix typing errors in `can_parse`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ matrix:
     - os: windows
       language: sh
       before_install:
-        # this hackery is in here because of https://github.com/git-for-windows/git/issues/2291
-        - powershell mkdir "'C:\Program Files\Git\dev'"
-        - ln -s /proc/self/fd /dev/fd
         - choco install make
         - choco install python
         - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ mypy
 pytest>=4.4.0
 pytest-cov
 pytest-xdist
-python-magic
+python-magic <= 0.4.15
 -r requirements.txt

--- a/slicedimage/io/_v0_0_0.py
+++ b/slicedimage/io/_v0_0_0.py
@@ -25,7 +25,7 @@ class v0_0_0:
 
     class Reader(_base.Reader):
         @classmethod
-        def can_parse(cls, doc_version: str):
+        def can_parse(cls, doc_version: version.Version):
             return (
                 version.parse(v0_0_0.VERSION)
                 <= doc_version

--- a/slicedimage/io/_v0_1_0.py
+++ b/slicedimage/io/_v0_1_0.py
@@ -26,7 +26,7 @@ class v0_1_0:
 
     class Reader(_base.Reader):
         @classmethod
-        def can_parse(cls, doc_version: str):
+        def can_parse(cls, doc_version: version.Version):
             return (
                 version.parse(v0_1_0.VERSION)
                 <= doc_version


### PR DESCRIPTION
doc_version should be of instance `version.Version`

Couple additional build-related issues:

1. hackery for Windows builds no longer necessary!
2. running into https://github.com/ahupp/python-magic/issues/213, so pinning python-magic to an earlier version.
